### PR TITLE
Host tests for status logic

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -1,0 +1,44 @@
+name: host-tests
+
+on:
+  push:
+    paths:
+      - "main/include/printsphere/printer_state.hpp"
+      - "main/include/printsphere/bambu_status.hpp"
+      - "main/include/printsphere/status_resolver.hpp"
+      - "main/include/printsphere/error_lookup.hpp"
+      - "main/src/printer_state.cpp"
+      - "main/src/bambu_status.cpp"
+      - "main/src/status_resolver.cpp"
+      - "tests/host/**"
+      - ".github/workflows/host-tests.yml"
+  pull_request:
+    paths:
+      - "main/include/printsphere/printer_state.hpp"
+      - "main/include/printsphere/bambu_status.hpp"
+      - "main/include/printsphere/status_resolver.hpp"
+      - "main/include/printsphere/error_lookup.hpp"
+      - "main/src/printer_state.cpp"
+      - "main/src/bambu_status.cpp"
+      - "main/src/status_resolver.cpp"
+      - "tests/host/**"
+      - ".github/workflows/host-tests.yml"
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build g++
+
+      - name: Configure
+        run: cmake -S tests/host -B tests/host/build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build
+        run: cmake --build tests/host/build --parallel
+
+      - name: Run tests
+        working-directory: tests/host/build
+        run: ctest --output-on-failure

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.16)
+project(printsphere_host_tests CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)
+endif()
+
+if(MSVC)
+    add_compile_options(/W4 /permissive-)
+else()
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+include(FetchContent)
+set(CMAKE_POLICY_VERSION_MINIMUM "3.5" CACHE STRING "" FORCE)
+FetchContent_Declare(
+    doctest
+    GIT_REPOSITORY https://github.com/doctest/doctest.git
+    GIT_TAG v2.5.2
+)
+FetchContent_MakeAvailable(doctest)
+
+set(REPO_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+
+add_executable(host_tests
+    main_test.cpp
+    test_bambu_status.cpp
+    test_printer_state.cpp
+    test_status_resolver.cpp
+    stubs/error_lookup_stub.cpp
+    "${REPO_ROOT}/main/src/bambu_status.cpp"
+    "${REPO_ROOT}/main/src/printer_state.cpp"
+    "${REPO_ROOT}/main/src/status_resolver.cpp"
+)
+
+target_include_directories(host_tests PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/stubs"
+    "${REPO_ROOT}/main/include"
+)
+
+target_link_libraries(host_tests PRIVATE doctest::doctest)
+
+enable_testing()
+include("${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake")
+doctest_discover_tests(host_tests)

--- a/tests/host/main_test.cpp
+++ b/tests/host/main_test.cpp
@@ -1,0 +1,2 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest/doctest.h"

--- a/tests/host/stubs/error_lookup_stub.cpp
+++ b/tests/host/stubs/error_lookup_stub.cpp
@@ -1,0 +1,36 @@
+#include "printsphere/error_lookup.hpp"
+
+#include <cstdio>
+#include <string>
+
+namespace printsphere {
+
+bool initialize_error_lookup_storage() { return true; }
+
+std::string lookup_error_text(ErrorLookupDomain, uint64_t code, PrinterModel) {
+  char buffer[32];
+  std::snprintf(buffer, sizeof(buffer), "code_%llu", static_cast<unsigned long long>(code));
+  return buffer;
+}
+
+std::string format_resolved_error_detail(
+  int print_error_code,
+  const std::vector<uint64_t>& hms_codes, int /*hms_count*/,
+  PrinterModel
+) {
+  if (print_error_code != 0) {
+    char buffer[32];
+    std::snprintf(buffer, sizeof(buffer), "print_err_%d", print_error_code);
+    return buffer;
+  }
+
+  if (!hms_codes.empty()) {
+    char buffer[32];
+    std::snprintf(buffer, sizeof(buffer), "hms_%llu", static_cast<unsigned long long>(hms_codes.front()));
+    return buffer;
+  }
+  
+  return {};
+}
+
+}  // namespace printsphere

--- a/tests/host/stubs/esp_err.h
+++ b/tests/host/stubs/esp_err.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// Host-build stub for ESP-IDFs <esp_err.h>
+// Only the bits needed by code under test are defined
+
+#include <cstdint>
+
+typedef int esp_err_t;
+
+#define ESP_OK    0
+#define ESP_FAIL -1
+
+#define ESP_ERR_NO_MEM           0x101
+#define ESP_ERR_INVALID_ARG      0x102
+#define ESP_ERR_INVALID_STATE    0x103
+#define ESP_ERR_INVALID_SIZE     0x104
+#define ESP_ERR_NOT_FOUND        0x105
+#define ESP_ERR_NOT_SUPPORTED    0x106
+#define ESP_ERR_TIMEOUT          0x107

--- a/tests/host/stubs/esp_log.h
+++ b/tests/host/stubs/esp_log.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// Host-build stub for ESP-IDFs <esp_log.h>
+// All macros are no-ops
+
+#define ESP_LOGE(tag, ...) ((void)0)
+#define ESP_LOGW(tag, ...) ((void)0)
+#define ESP_LOGI(tag, ...) ((void)0)
+#define ESP_LOGD(tag, ...) ((void)0)
+#define ESP_LOGV(tag, ...) ((void)0)
+
+#define ESP_EARLY_LOGE(tag, ...) ((void)0)
+#define ESP_EARLY_LOGW(tag, ...) ((void)0)
+#define ESP_EARLY_LOGI(tag, ...) ((void)0)
+#define ESP_EARLY_LOGD(tag, ...) ((void)0)
+#define ESP_EARLY_LOGV(tag, ...) ((void)0)
+
+inline void esp_log_level_set(const char*, int) {}
+
+enum {
+  ESP_LOG_NONE,
+  ESP_LOG_ERROR,
+  ESP_LOG_WARN,
+  ESP_LOG_INFO,
+  ESP_LOG_DEBUG,
+  ESP_LOG_VERBOSE,
+};

--- a/tests/host/stubs/freertos/FreeRTOS.h
+++ b/tests/host/stubs/freertos/FreeRTOS.h
@@ -1,0 +1,18 @@
+#pragma once
+
+// Host-build stub for FreeRTOS.h
+// Only the type aliases referenced by data-only headers under test are provided
+
+#include <cstdint>
+
+typedef uint32_t TickType_t;
+typedef int      BaseType_t;
+typedef unsigned UBaseType_t;
+
+#define portMAX_DELAY ((TickType_t)0xFFFFFFFFU)
+#define pdPASS        ((BaseType_t)1)
+#define pdFAIL        ((BaseType_t)0)
+#define pdTRUE        ((BaseType_t)1)
+#define pdFALSE       ((BaseType_t)0)
+
+inline TickType_t pdMS_TO_TICKS(uint32_t ms) { return ms; }

--- a/tests/host/stubs/freertos/task.h
+++ b/tests/host/stubs/freertos/task.h
@@ -1,0 +1,16 @@
+#pragma once
+
+// Host-build stub for freertos/task.h
+
+#include "freertos/FreeRTOS.h"
+
+typedef void* TaskHandle_t;
+
+inline BaseType_t xTaskCreate(void (*)(void*), const char*, uint32_t, void*, UBaseType_t, TaskHandle_t*) {
+  return pdPASS;
+}
+
+inline void vTaskDelay(TickType_t) {}
+inline void vTaskDelete(TaskHandle_t) {}
+inline TickType_t xTaskGetTickCount() { return 0; }
+inline void xTaskNotifyGive(TaskHandle_t) {}

--- a/tests/host/stubs/mqtt_client.h
+++ b/tests/host/stubs/mqtt_client.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// Host-build stub for ESP-IDFs <mqtt_client.h>
+// Only the type aliases and enums referenced by headers under test are provided
+
+#include <cstdint>
+
+typedef const char* esp_event_base_t;
+typedef void* esp_mqtt_client_handle_t;
+typedef void* esp_mqtt_event_handle_t;
+
+enum {
+  MQTT_CONNECTION_ACCEPTED = 0,
+};

--- a/tests/host/test_bambu_status.cpp
+++ b/tests/host/test_bambu_status.cpp
@@ -1,0 +1,121 @@
+#include "doctest/doctest.h"
+
+#include "printsphere/bambu_status.hpp"
+
+using namespace printsphere;
+
+TEST_CASE("normalize_bambu_status_token strips non-alnum and uppercases") {
+  CHECK(normalize_bambu_status_token("running") == "RUNNING");
+  CHECK(normalize_bambu_status_token("X1-Carbon") == "X1CARBON");
+  CHECK(normalize_bambu_status_token("  in_progress  ") == "INPROGRESS");
+  CHECK(normalize_bambu_status_token("") == "");
+}
+
+TEST_CASE("bambu_model_from_product_name maps known marketing names") {
+  CHECK(bambu_model_from_product_name("A1 mini") == PrinterModel::kA1Mini);
+  CHECK(bambu_model_from_product_name("Bambu Lab A1") == PrinterModel::kA1);
+  CHECK(bambu_model_from_product_name("A1") == PrinterModel::kA1);
+  CHECK(bambu_model_from_product_name("P1S") == PrinterModel::kP1S);
+  CHECK(bambu_model_from_product_name("P1P") == PrinterModel::kP1P);
+  CHECK(bambu_model_from_product_name("P2S") == PrinterModel::kP2S);
+  CHECK(bambu_model_from_product_name("H2D Pro") == PrinterModel::kH2DPro);
+  CHECK(bambu_model_from_product_name("H2D") == PrinterModel::kH2D);
+  CHECK(bambu_model_from_product_name("H2S") == PrinterModel::kH2S);
+  CHECK(bambu_model_from_product_name("H2C") == PrinterModel::kH2C);
+  CHECK(bambu_model_from_product_name("X1E") == PrinterModel::kX1E);
+  CHECK(bambu_model_from_product_name("X1 Carbon") == PrinterModel::kX1C);
+  CHECK(bambu_model_from_product_name("X1C") == PrinterModel::kX1C);
+  CHECK(bambu_model_from_product_name("X1") == PrinterModel::kX1);
+  CHECK(bambu_model_from_product_name("Toaster") == PrinterModel::kUnknown);
+  CHECK(bambu_model_from_product_name("") == PrinterModel::kUnknown);
+}
+
+TEST_CASE("bambu status family predicates") {
+  SUBCASE("failed family") {
+    CHECK(bambu_status_is_failed("FAILED"));
+    CHECK(bambu_status_is_failed("Cancelled"));
+    CHECK(bambu_status_is_failed("ERROR"));
+    CHECK_FALSE(bambu_status_is_failed("RUNNING"));
+  }
+  SUBCASE("finished family") {
+    CHECK(bambu_status_is_finished("FINISH"));
+    CHECK(bambu_status_is_finished("Done"));
+    CHECK(bambu_status_is_finished("SUCCESS"));
+    CHECK(bambu_status_is_finished("Completed"));
+    CHECK_FALSE(bambu_status_is_finished("RUNNING"));
+  }
+  SUBCASE("paused family") {
+    CHECK(bambu_status_is_paused("PAUSE"));
+    CHECK(bambu_status_is_paused("paused"));
+    CHECK_FALSE(bambu_status_is_paused("RUNNING"));
+  }
+  SUBCASE("preparing family") {
+    CHECK(bambu_status_is_preparing("INIT"));
+    CHECK(bambu_status_is_preparing("Slicing"));
+    CHECK(bambu_status_is_preparing("Heating"));
+    CHECK(bambu_status_is_preparing("Downloading"));
+    CHECK(bambu_status_is_preparing("Preparing"));
+    CHECK(bambu_status_is_preparing("Starting"));
+    CHECK_FALSE(bambu_status_is_preparing("RUNNING"));
+  }
+  SUBCASE("printing family") {
+    CHECK(bambu_status_is_printing("RUNNING"));
+    CHECK(bambu_status_is_printing("Printing"));
+    CHECK(bambu_status_is_printing("PROCESSING"));
+    CHECK_FALSE(bambu_status_is_printing("PAUSE"));
+  }
+}
+
+TEST_CASE("lifecycle_from_bambu_status") {
+  CHECK(lifecycle_from_bambu_status("RUNNING", false) == PrintLifecycleState::kPrinting);
+  CHECK(lifecycle_from_bambu_status("PAUSE", false) == PrintLifecycleState::kPaused);
+  CHECK(lifecycle_from_bambu_status("FINISH", false) == PrintLifecycleState::kFinished);
+  CHECK(lifecycle_from_bambu_status("FAILED", false) == PrintLifecycleState::kError);
+  CHECK(lifecycle_from_bambu_status("PREPARE", false) == PrintLifecycleState::kPreparing);
+  CHECK(lifecycle_from_bambu_status("IDLE", false) == PrintLifecycleState::kIdle);
+  CHECK(lifecycle_from_bambu_status("OFFLINE", false) == PrintLifecycleState::kIdle);
+  CHECK(lifecycle_from_bambu_status("UNKNOWN", false) == PrintLifecycleState::kUnknown);
+  CHECK(lifecycle_from_bambu_status("", false) == PrintLifecycleState::kUnknown);
+
+  // has_concrete_error wins over text
+  CHECK(lifecycle_from_bambu_status("RUNNING", true) == PrintLifecycleState::kError);
+  CHECK(lifecycle_from_bambu_status("FINISH", true) == PrintLifecycleState::kError);
+}
+
+TEST_CASE("bambu_pretty_status") {
+  CHECK(bambu_pretty_status("Downloading model").compare("downloading") == 0);
+  CHECK(bambu_pretty_status("FINISH") == "done");
+  CHECK(bambu_pretty_status("FAILED") == "failed");
+  CHECK(bambu_pretty_status("PAUSE") == "paused");
+  CHECK(bambu_pretty_status("PREPARE") == "preparing");
+  CHECK(bambu_pretty_status("RUNNING") == "printing");
+  CHECK(bambu_pretty_status("OFFLINE") == "offline");
+  CHECK(bambu_pretty_status("IDLE") == "idle");
+  CHECK(bambu_pretty_status("UNKNOWN").empty());
+  CHECK(bambu_pretty_status("").empty());
+}
+
+TEST_CASE("bambu_default_stage_label_for_status") {
+  CHECK(bambu_default_stage_label_for_status("RUNNING", false) == "Printing");
+  CHECK(bambu_default_stage_label_for_status("Downloading", false) == "Model Download");
+  CHECK(bambu_default_stage_label_for_status("PAUSE", false) == "Paused");
+  CHECK(bambu_default_stage_label_for_status("PREPARE", false) == "Preparing");
+  CHECK(bambu_default_stage_label_for_status("FINISH", false) == "Finished");
+  CHECK(bambu_default_stage_label_for_status("IDLE", false) == "Idle");
+  CHECK(bambu_default_stage_label_for_status("OFFLINE", false) == "Offline");
+  CHECK(bambu_default_stage_label_for_status("FAILED", false) == "Stopped");
+  CHECK(bambu_default_stage_label_for_status("FAILED", true) == "Failed");
+  CHECK(bambu_default_stage_label_for_status("", false) == "Status");
+}
+
+TEST_CASE("bambu_stage_label_from_id covers known stages and idle sentinels") {
+  CHECK(bambu_stage_label_from_id(0) == "printing");
+  CHECK(bambu_stage_label_from_id(2) == "heatbed_preheating");
+  CHECK(bambu_stage_label_from_id(4) == "changing_filament");
+  CHECK(bambu_stage_label_from_id(7) == "heating_hotend");
+  CHECK(bambu_stage_label_from_id(22) == "filament_unloading");
+  CHECK(bambu_stage_label_from_id(24) == "filament_loading");
+  CHECK(bambu_stage_label_from_id(-1) == "idle");
+  CHECK(bambu_stage_label_from_id(255) == "idle");
+  CHECK(bambu_stage_label_from_id(99999).empty());
+}

--- a/tests/host/test_printer_state.cpp
+++ b/tests/host/test_printer_state.cpp
@@ -1,0 +1,216 @@
+#include "doctest/doctest.h"
+
+#include <array>
+
+#include "printsphere/printer_state.hpp"
+
+using namespace printsphere;
+
+namespace {
+
+constexpr std::array<PrinterModel, 12> kAllModels{
+    PrinterModel::kA1,  PrinterModel::kA1Mini,  PrinterModel::kP1P,
+    PrinterModel::kP1S, PrinterModel::kP2S,     PrinterModel::kH2C,
+    PrinterModel::kH2D, PrinterModel::kH2DPro,  PrinterModel::kH2S,
+    PrinterModel::kX1,  PrinterModel::kX1C,     PrinterModel::kX1E,
+};
+
+}  // namespace
+
+TEST_CASE("PrinterStateStore round-trips a snapshot") {
+  PrinterStateStore store;
+  PrinterSnapshot in;
+  in.connection = PrinterConnectionState::kOnline;
+  in.lifecycle = PrintLifecycleState::kPrinting;
+  in.progress_percent = 42.5f;
+  in.current_layer = 17;
+  in.total_layers = 200;
+  in.local_model = PrinterModel::kP1S;
+  store.set_snapshot(in);
+
+  const PrinterSnapshot out = store.snapshot();
+  CHECK(out.connection == PrinterConnectionState::kOnline);
+  CHECK(out.lifecycle == PrintLifecycleState::kPrinting);
+  CHECK(out.progress_percent == doctest::Approx(42.5f));
+  CHECK(out.current_layer == 17);
+  CHECK(out.total_layers == 200);
+  CHECK(out.local_model == PrinterModel::kP1S);
+}
+
+TEST_CASE("printer_model_has_jpeg_camera matches the documented set") {
+  CHECK(printer_model_has_jpeg_camera(PrinterModel::kA1));
+  CHECK(printer_model_has_jpeg_camera(PrinterModel::kA1Mini));
+  CHECK(printer_model_has_jpeg_camera(PrinterModel::kP1P));
+  CHECK(printer_model_has_jpeg_camera(PrinterModel::kP1S));
+
+  CHECK_FALSE(printer_model_has_jpeg_camera(PrinterModel::kP2S));
+  CHECK_FALSE(printer_model_has_jpeg_camera(PrinterModel::kH2C));
+  CHECK_FALSE(printer_model_has_jpeg_camera(PrinterModel::kH2D));
+  CHECK_FALSE(printer_model_has_jpeg_camera(PrinterModel::kH2DPro));
+  CHECK_FALSE(printer_model_has_jpeg_camera(PrinterModel::kH2S));
+  CHECK_FALSE(printer_model_has_jpeg_camera(PrinterModel::kX1));
+  CHECK_FALSE(printer_model_has_jpeg_camera(PrinterModel::kX1C));
+  CHECK_FALSE(printer_model_has_jpeg_camera(PrinterModel::kX1E));
+  CHECK_FALSE(printer_model_has_jpeg_camera(PrinterModel::kUnknown));
+}
+
+TEST_CASE("printer_model_has_rtsp_camera covers RTSP-only models") {
+  CHECK(printer_model_has_rtsp_camera(PrinterModel::kP2S));
+  CHECK(printer_model_has_rtsp_camera(PrinterModel::kH2C));
+  CHECK(printer_model_has_rtsp_camera(PrinterModel::kH2D));
+  CHECK(printer_model_has_rtsp_camera(PrinterModel::kH2DPro));
+  CHECK(printer_model_has_rtsp_camera(PrinterModel::kH2S));
+  CHECK(printer_model_has_rtsp_camera(PrinterModel::kX1));
+  CHECK(printer_model_has_rtsp_camera(PrinterModel::kX1C));
+  CHECK(printer_model_has_rtsp_camera(PrinterModel::kX1E));
+  
+  CHECK_FALSE(printer_model_has_rtsp_camera(PrinterModel::kA1));
+  CHECK_FALSE(printer_model_has_rtsp_camera(PrinterModel::kP1S));
+}
+
+TEST_CASE("camera capabilities are mutually exclusive (current model set)") {
+  // NOTE: Every known model should expose at most one camera transport
+  // NOTE: Probably a future model exposes both, this test should be updated deliberately
+  for (const PrinterModel model : kAllModels) {
+    CAPTURE(to_string(model));
+    const bool both = printer_model_has_jpeg_camera(model) &&
+                      printer_model_has_rtsp_camera(model);
+    CHECK_FALSE(both);
+  }
+}
+
+TEST_CASE("printer_model_has_chamber_temperature") {
+  CHECK(printer_model_has_chamber_temperature(PrinterModel::kP2S));
+  CHECK(printer_model_has_chamber_temperature(PrinterModel::kH2D));
+  CHECK(printer_model_has_chamber_temperature(PrinterModel::kX1C));
+
+  CHECK_FALSE(printer_model_has_chamber_temperature(PrinterModel::kA1));
+  CHECK_FALSE(printer_model_has_chamber_temperature(PrinterModel::kA1Mini));
+  CHECK_FALSE(printer_model_has_chamber_temperature(PrinterModel::kP1P));
+  CHECK_FALSE(printer_model_has_chamber_temperature(PrinterModel::kP1S));
+}
+
+TEST_CASE("printer_model_has_secondary_nozzle_temperature only on H2D family") {
+  CHECK(printer_model_has_secondary_nozzle_temperature(PrinterModel::kH2D));
+  CHECK(printer_model_has_secondary_nozzle_temperature(PrinterModel::kH2DPro));
+
+  for (const PrinterModel model : kAllModels) {
+    if (model == PrinterModel::kH2D || model == PrinterModel::kH2DPro) {
+      continue;
+    }
+
+    CAPTURE(to_string(model));
+    CHECK_FALSE(printer_model_has_secondary_nozzle_temperature(model));
+  }
+}
+
+TEST_CASE("printer_model_has_chamber_light excludes A1 / P1P") {
+  CHECK(printer_model_has_chamber_light(PrinterModel::kP1S));
+  CHECK(printer_model_has_chamber_light(PrinterModel::kP2S));
+  CHECK(printer_model_has_chamber_light(PrinterModel::kX1C));
+  CHECK(printer_model_has_chamber_light(PrinterModel::kH2D));
+
+  CHECK_FALSE(printer_model_has_chamber_light(PrinterModel::kA1));
+  CHECK_FALSE(printer_model_has_chamber_light(PrinterModel::kA1Mini));
+  CHECK_FALSE(printer_model_has_chamber_light(PrinterModel::kP1P));
+}
+
+TEST_CASE("printer_model_has_secondary_chamber_light only on H2 family") {
+  CHECK(printer_model_has_secondary_chamber_light(PrinterModel::kH2C));
+  CHECK(printer_model_has_secondary_chamber_light(PrinterModel::kH2D));
+  CHECK(printer_model_has_secondary_chamber_light(PrinterModel::kH2DPro));
+  CHECK(printer_model_has_secondary_chamber_light(PrinterModel::kH2S));
+
+  CHECK_FALSE(printer_model_has_secondary_chamber_light(PrinterModel::kP1S));
+  CHECK_FALSE(printer_model_has_secondary_chamber_light(PrinterModel::kX1C));
+}
+
+TEST_CASE("printer_model_supports_local_status is true for every known model") {
+  for (const PrinterModel model : kAllModels) {
+    CAPTURE(to_string(model));
+    CHECK(printer_model_supports_local_status(model));
+  }
+
+  CHECK(printer_model_supports_local_status(PrinterModel::kUnknown));
+}
+
+TEST_CASE("printer_model_requires_developer_mode_for_local_status only H2 family") {
+  CHECK(printer_model_requires_developer_mode_for_local_status(PrinterModel::kH2C));
+  CHECK(printer_model_requires_developer_mode_for_local_status(PrinterModel::kH2D));
+  CHECK(printer_model_requires_developer_mode_for_local_status(PrinterModel::kH2DPro));
+  CHECK(printer_model_requires_developer_mode_for_local_status(PrinterModel::kH2S));
+
+  CHECK_FALSE(printer_model_requires_developer_mode_for_local_status(PrinterModel::kP2S));
+  CHECK_FALSE(printer_model_requires_developer_mode_for_local_status(PrinterModel::kP1S));
+  CHECK_FALSE(printer_model_requires_developer_mode_for_local_status(PrinterModel::kX1));
+}
+
+TEST_CASE("printer_model_prefers_cloud_status covers P2S and H2 family only") {
+  CHECK(printer_model_prefers_cloud_status(PrinterModel::kP2S));
+  CHECK(printer_model_prefers_cloud_status(PrinterModel::kH2C));
+  CHECK(printer_model_prefers_cloud_status(PrinterModel::kH2D));
+  CHECK(printer_model_prefers_cloud_status(PrinterModel::kH2DPro));
+  CHECK(printer_model_prefers_cloud_status(PrinterModel::kH2S));
+
+  for (const PrinterModel model : kAllModels) {
+    if (model == PrinterModel::kP2S) {
+      continue;
+    }
+    
+    if (model == PrinterModel::kH2C || model == PrinterModel::kH2D ||
+        model == PrinterModel::kH2DPro || model == PrinterModel::kH2S) {
+      continue;
+    }
+
+    CAPTURE(to_string(model));
+    CHECK_FALSE(printer_model_prefers_cloud_status(model));
+  }
+}
+
+TEST_CASE("printer_serial_family_has_no_chamber_temperature") {
+  CHECK(printer_serial_family_has_no_chamber_temperature("01P12345"));
+  CHECK(printer_serial_family_has_no_chamber_temperature("01p12345"));
+
+  CHECK_FALSE(printer_serial_family_has_no_chamber_temperature("00M12345"));
+  CHECK_FALSE(printer_serial_family_has_no_chamber_temperature("01"));
+  CHECK_FALSE(printer_serial_family_has_no_chamber_temperature(""));
+}
+
+TEST_CASE("default_local_capabilities_for_model wires capability table to traits") {
+  const SourceCapabilities p1s = default_local_capabilities_for_model(PrinterModel::kP1S);
+
+  CHECK(p1s.status);
+  CHECK(p1s.metrics);
+  CHECK(p1s.temperatures);
+  CHECK(p1s.hms);
+  CHECK(p1s.print_error);
+  CHECK(p1s.camera_jpeg_socket);
+  CHECK_FALSE(p1s.camera_rtsp);
+  CHECK_FALSE(p1s.developer_mode_required);
+
+  const SourceCapabilities h2d = default_local_capabilities_for_model(PrinterModel::kH2D);
+  CHECK(h2d.camera_rtsp);
+  CHECK_FALSE(h2d.camera_jpeg_socket);
+  CHECK(h2d.developer_mode_required);
+}
+
+TEST_CASE("default_cloud_capabilities is the full set including preview") {
+  const SourceCapabilities cloud = default_cloud_capabilities();
+  CHECK(cloud.status);
+  CHECK(cloud.metrics);
+  CHECK(cloud.temperatures);
+  CHECK(cloud.preview);
+  CHECK(cloud.hms);
+  CHECK(cloud.print_error);
+  CHECK_FALSE(cloud.camera_jpeg_socket);
+  CHECK_FALSE(cloud.camera_rtsp);
+}
+
+TEST_CASE("to_string for PrinterModel covers every value") {
+  for (const PrinterModel model : kAllModels) {
+    CHECK(to_string(model) != nullptr);
+    CHECK(to_string(model)[0] != '\0');
+  }
+  
+  CHECK(std::string(to_string(PrinterModel::kUnknown)) == "UNKNOWN");
+}

--- a/tests/host/test_status_resolver.cpp
+++ b/tests/host/test_status_resolver.cpp
@@ -1,0 +1,269 @@
+#include "doctest/doctest.h"
+
+#include <string>
+
+#include "printsphere/bambu_cloud_client.hpp"
+#include "printsphere/printer_state.hpp"
+#include "printsphere/status_resolver.hpp"
+
+using namespace printsphere;
+
+namespace {
+
+// All freshness windows in status_resolver.cpp are evaluated as
+// "now_ms - last_update_ms < window"
+// 
+// Picking a now_ms large enough that any "now_ms" in tests is
+// comfortably ahead of "last_update_ms = now_ms - 1000"
+constexpr uint64_t kNowMs = 1'000'000ULL;
+
+// Constructor for fake PrinterSnaphot
+PrinterSnapshot make_local_printing(PrinterModel model = PrinterModel::kP1S) {
+  PrinterSnapshot s;
+
+  s.connection = PrinterConnectionState::kOnline;
+  s.lifecycle = PrintLifecycleState::kPrinting;
+  s.local_configured = true;
+  s.local_connected = true;
+  s.local_last_update_ms = kNowMs - 1000;
+  s.local_model = model;
+  s.local_capabilities = default_local_capabilities_for_model(model);
+  s.raw_status = "RUNNING";
+  s.raw_stage = "printing";
+  s.stage = "printing";
+  s.detail = "Local print in progress";
+  s.progress_percent = 33.0f;
+  s.current_layer = 50;
+  s.total_layers = 200;
+  s.nozzle_temp_c = 215.0f;
+  s.nozzle_temp_known = true;
+  s.bed_temp_c = 60.0f;
+  s.bed_temp_known = true;
+  s.job_name = "local_job.gcode";
+
+  return s;
+}
+
+// Same constructor but for cloud snapshot
+BambuCloudSnapshot make_cloud_printing(PrinterModel model = PrinterModel::kP1S) {
+  BambuCloudSnapshot c;
+
+  c.configured = true;
+  c.connected = true;
+  c.last_update_ms = kNowMs - 1000;
+  c.model = model;
+  c.capabilities = default_cloud_capabilities();
+  c.lifecycle = PrintLifecycleState::kPrinting;
+  c.detail = "Cloud reports running";
+  c.raw_status = "RUNNING";
+  c.raw_stage = "printing";
+  c.stage = "printing";
+  c.progress_percent = 67.0f;
+  c.current_layer = 80;
+  c.total_layers = 200;
+  c.nozzle_temp_c = 220.0f;
+  c.nozzle_temp_last_update_ms = kNowMs - 1000;
+  c.bed_temp_c = 60.0f;
+  c.bed_temp_last_update_ms = kNowMs - 1000;
+  c.preview_title = "cloud_job";
+
+  return c;
+}
+
+}  // namespace
+
+TEST_CASE("is_download_stage matches stage and status tokens") {
+  CHECK(is_download_stage("model_download", ""));
+  CHECK(is_download_stage("downloading", ""));
+  CHECK(is_download_stage("", "downloading file"));
+
+  CHECK_FALSE(is_download_stage("printing", "running"));
+  CHECK_FALSE(is_download_stage("", ""));
+}
+
+TEST_CASE("is_filament_stage covers AMS load/unload/change") {
+  CHECK(is_filament_stage("filament_loading"));
+  CHECK(is_filament_stage("filament_unloading"));
+  CHECK(is_filament_stage("changing_filament"));
+  CHECK(is_filament_stage("Filament_Loading"));  // case insensitive
+
+  CHECK_FALSE(is_filament_stage("printing"));
+  CHECK_FALSE(is_filament_stage(""));
+}
+
+TEST_CASE("is_post_download_handoff_stage excludes the download stage itself") {
+  CHECK_FALSE(is_post_download_handoff_stage("model_download", ""));
+  CHECK_FALSE(is_post_download_handoff_stage("", "downloading"));
+
+  CHECK(is_post_download_handoff_stage("filament_loading", ""));
+  CHECK(is_post_download_handoff_stage("printing", ""));
+  CHECK(is_post_download_handoff_stage("heatbed_preheating", ""));
+}
+
+TEST_CASE("resolve_ui_state sets a sensible ui_status for an idle local printer") {
+  PrinterSnapshot s;
+
+  s.wifi_connected = true;
+  s.connection = PrinterConnectionState::kOnline;
+  s.lifecycle = PrintLifecycleState::kIdle;
+  s.raw_status = "IDLE";
+  s.local_connected = true;
+
+  resolve_ui_state(s);
+
+  CHECK(s.ui_status == "idle");
+  CHECK_FALSE(s.print_active);
+  CHECK_FALSE(s.has_error);
+}
+
+TEST_CASE("resolve_ui_state flags has_error when a print error code is present") {
+  PrinterSnapshot s;
+
+  s.wifi_connected = true;
+  s.connection = PrinterConnectionState::kOnline;
+  s.local_connected = true;
+  s.lifecycle = PrintLifecycleState::kPrinting;
+  s.raw_status = "RUNNING";
+  s.raw_stage = "printing";
+  s.print_error_code = 0x0500'1000;  // arbitrary non-zero
+
+  resolve_ui_state(s);
+
+  CHECK(s.has_error);
+  CHECK(s.lifecycle == PrintLifecycleState::kError);
+}
+
+TEST_CASE("merge_status_sources cloud-only mode picks cloud everywhere") {
+  PrinterSnapshot local; // unconfigured
+  BambuCloudSnapshot cloud = make_cloud_printing();
+
+  const PrinterSnapshot merged = merge_status_sources(
+      local, /*local_printer_enabled=*/false, cloud, SourceMode::kCloudOnly,
+      kNowMs, /*wifi_connected=*/true, "192.168.1.10",
+      /*print_activity_seen_this_session=*/false);
+
+  CHECK(merged.cloud_configured);
+  CHECK(merged.cloud_connected);
+  CHECK(merged.status_source == FieldSource::kCloud);
+  CHECK(merged.metrics_source == FieldSource::kCloud);
+  CHECK(merged.lifecycle == PrintLifecycleState::kPrinting);
+  CHECK(merged.progress_percent == doctest::Approx(67.0f));
+  CHECK(merged.current_layer == 80);
+  CHECK(merged.total_layers == 200);
+
+  CHECK_FALSE(merged.local_configured);
+}
+
+TEST_CASE("merge_status_sources local-only mode ignores cloud entirely") {
+  PrinterSnapshot local = make_local_printing(PrinterModel::kP1S);
+  BambuCloudSnapshot cloud = make_cloud_printing(PrinterModel::kP1S);
+
+  const PrinterSnapshot merged = merge_status_sources(
+      local, /*local_printer_enabled=*/true, cloud, SourceMode::kLocalOnly,
+      kNowMs, true, "192.168.1.10", false);
+
+  CHECK(merged.local_configured);
+  CHECK(merged.local_connected);
+  CHECK(merged.status_source == FieldSource::kLocal);
+  CHECK(merged.metrics_source == FieldSource::kLocal);
+  CHECK(merged.progress_percent == doctest::Approx(33.0f));
+  CHECK(merged.current_layer == 50);
+
+  // Cloud preview must NOT leak into local-only mode
+  CHECK(merged.preview_source == FieldSource::kNone);
+}
+
+TEST_CASE("merge_status_sources hybrid prefers local for P1S (local-favoring model)") {
+  PrinterSnapshot local = make_local_printing(PrinterModel::kP1S);
+  BambuCloudSnapshot cloud = make_cloud_printing(PrinterModel::kP1S);
+
+  const PrinterSnapshot merged = merge_status_sources(
+      local, true, cloud, SourceMode::kHybrid, kNowMs, true, "192.168.1.10", false);
+
+  CHECK(merged.status_source == FieldSource::kLocal);
+  CHECK(merged.metrics_source == FieldSource::kLocal);
+  CHECK(merged.progress_percent == doctest::Approx(33.0f));
+}
+
+TEST_CASE("merge_status_sources hybrid prefers cloud for P2S (cloud-favoring model)") {
+  PrinterSnapshot local = make_local_printing(PrinterModel::kP2S);
+  BambuCloudSnapshot cloud = make_cloud_printing(PrinterModel::kP2S);
+
+  const PrinterSnapshot merged = merge_status_sources(
+      local, true, cloud, SourceMode::kHybrid, kNowMs, true, "192.168.1.10", false);
+
+  CHECK(merged.status_source == FieldSource::kCloud);
+  CHECK(merged.metrics_source == FieldSource::kCloud);
+  CHECK(merged.progress_percent == doctest::Approx(67.0f));
+}
+
+TEST_CASE("merge_status_sources hybrid falls back to cloud when local is stale") {
+  PrinterSnapshot local = make_local_printing(PrinterModel::kP1S);
+  BambuCloudSnapshot cloud = make_cloud_printing(PrinterModel::kP1S);
+
+  // Push local last update beyond the 90s freshness window
+  local.local_last_update_ms = kNowMs - (90ULL * 1000ULL + 5'000ULL);
+
+  const PrinterSnapshot merged = merge_status_sources(
+      local, true, cloud, SourceMode::kHybrid, kNowMs, true, "192.168.1.10", false);
+
+  CHECK(merged.status_source == FieldSource::kCloud);
+  CHECK(merged.progress_percent == doctest::Approx(67.0f));
+}
+
+TEST_CASE("merge_status_sources strips chamber temperature for models that lack it") {
+  // Make sure the routing model resolves to P1S (no chamber temp)
+  BambuCloudSnapshot cloud; // not configured
+  PrinterSnapshot local = make_local_printing(PrinterModel::kP1S);
+
+  local.chamber_temp_c = 42.0f;
+  local.chamber_temp_known = true;
+
+  const PrinterSnapshot merged = merge_status_sources(
+      local, true, cloud, SourceMode::kLocalOnly, kNowMs, true, "192.168.1.10", false);
+
+  CHECK_FALSE(merged.chamber_temp_known);
+  CHECK(merged.chamber_temp_c == doctest::Approx(0.0f));
+}
+
+TEST_CASE("merge_status_sources keeps chamber temperature for models that support it") {
+  PrinterSnapshot local = make_local_printing(PrinterModel::kX1C);
+  BambuCloudSnapshot cloud; // not configured
+
+  local.chamber_temp_c = 42.0f;
+  local.chamber_temp_known = true;
+
+  const PrinterSnapshot merged = merge_status_sources(
+      local, true, cloud, SourceMode::kLocalOnly, kNowMs, true, "192.168.1.10", false);
+
+  CHECK(merged.chamber_temp_known);
+  CHECK(merged.chamber_temp_c == doctest::Approx(42.0f));
+}
+
+TEST_CASE("merge_status_sources cloud preview is exposed in cloud-capable modes") {
+  PrinterSnapshot local;
+  BambuCloudSnapshot cloud = make_cloud_printing();
+
+  cloud.preview_blob = std::make_shared<std::vector<uint8_t>>(std::vector<uint8_t>{1, 2, 3});
+  cloud.preview_url = "https://example.com/cover.png";
+
+  const PrinterSnapshot merged_cloud_only = merge_status_sources(
+      local, false, cloud, SourceMode::kCloudOnly, kNowMs, true, "192.168.1.10", false);
+  
+  CHECK(merged_cloud_only.preview_source == FieldSource::kCloud);
+  REQUIRE(merged_cloud_only.preview_blob.get() != nullptr);
+  CHECK(merged_cloud_only.preview_blob->size() == 3U);
+}
+
+TEST_CASE("merge_status_sources without any source falls back to setup state") {
+  PrinterSnapshot local;
+  BambuCloudSnapshot cloud;
+
+  const PrinterSnapshot merged = merge_status_sources(
+      local, /*local_printer_enabled=*/false, cloud, SourceMode::kHybrid, kNowMs,
+      /*wifi_connected=*/false, "", false);
+
+  CHECK(merged.connection == PrinterConnectionState::kWaitingForCredentials);
+  CHECK(merged.lifecycle == PrintLifecycleState::kUnknown);
+  CHECK(merged.stage == "setup");
+}


### PR DESCRIPTION
## Hi!
Hey - got my P2S a couple weeks back and stumbled onto PrintSphere shortly after

Really liked the idea of a small dedicated screen for the printer instead of pulling out my phone every time, so I figured I'd start contributing back (when I have some free time from job, family, etc.)

This PR is my first step

## Why I started here

I was poking around the codebase planning some cleanups (_because code looks like a pile of noodles tbh_) and noticed three modules do a lot of heavy lifting for the UI - `status_resolver`, `bambu_status` and `printer_state`

Lifecycle inference, hybrid cloud/local merge, per-model capability flags, status name normalization, all pure functions and all untested

That made me nervous about touching anything around them. Every change would need a flash + watch-the-screen cycle to verify, which is slow and easy to miss regressions in

I have a few follow-up cleanups in mind (parser dedup in the cloud client, collapsing the parallel model capability switches, unifying snapshot structs) but none of them feel safe without a regression net, so I figured (**basic**) tests come first

## What's in
* `tests/host/` - standalone CMake project, no ESP-IDF, doctest via FetchContent
* stubs for `esp_err.h`, `esp_log.h`, `freertos/*`, `mqtt_client.h` so the three sources compile on host
* **36** test cases covering the three modules
* GitHub Actions workflow, path-filtered, runs in ~2s on Ubuntu

No firmware sources touched, no device impact

## Not in scope (at least for now)
* MQTT client tests (too tangled with IDF internals for a host build)
* Coverage reporting

## What I'd like to do next
If this lands and the approach looks good to you, I'd love to follow up with the cleanups I mentioned - starting with collapsing the per-model capability switches into a single trait table

The tests here already pin the current behavior so it stays mechanical

Happy to adjust anything in this PR - structure, naming, coverage, whatever you'd prefer. Or just discuss with me and we'll figure it out together