### PR TITLE
Fix telemetry refresh and harden portal reliability

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -17,6 +17,7 @@ set(PRINTSPHERE_MAIN_REQUIRES
     esp_wifi
     libpng
     lvgl
+    mbedtls
     nvs_flash
     joltwallet__littlefs
 )

--- a/main/include/printsphere/application.hpp
+++ b/main/include/printsphere/application.hpp
@@ -40,6 +40,8 @@ class Application {
   SourceMode last_source_mode_ = SourceMode::kHybrid;
   bool last_wifi_connected_ = false;
   bool last_camera_page_active_ = false;
+  bool last_config_page_active_ = false;
+  bool last_config_local_connected_ = false;
   bool hybrid_local_gate_open_ = false;
   TickType_t hybrid_camera_cooldown_deadline_ = 0;
   std::atomic<TickType_t> local_mqtt_handoff_until_tick_{0};

--- a/main/include/printsphere/config_store.hpp
+++ b/main/include/printsphere/config_store.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <mutex>
 #include <string>
@@ -179,6 +180,9 @@ class ConfigStore {
   // callers (HTTP handlers on httpd task + main loop) cannot race and clobber
   // `prn_count` / profile slot assignments (see /api/printers/save upsert).
   mutable std::mutex printer_profile_mutex_{};
+  // -1 until first load; subsequent main-loop reads are served without opening
+  // NVS, while portal saves update the cached value immediately.
+  mutable std::atomic<int> cached_source_mode_{-1};
 };
 
 }  // namespace printsphere

--- a/main/include/printsphere/setup_portal.hpp
+++ b/main/include/printsphere/setup_portal.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <mutex>
 #include <string>
@@ -87,6 +88,7 @@ class SetupPortal {
 #endif
   static void ota_url_task(void* context);
   static void reboot_task(void* context);
+  bool schedule_reboot();
   bool is_provisioning_complete() const;
   bool is_lock_required() const;
   bool is_request_authorized(httpd_req_t* request);
@@ -106,7 +108,7 @@ class SetupPortal {
   const PmuManager& pmu_manager_;
   AudioNotifier& audio_notifier_;
   httpd_handle_t server_ = nullptr;
-  bool reboot_requested_ = false;
+  std::atomic<bool> reboot_requested_{false};
   std::mutex access_mutex_{};
   // OTA URL state (protected by ota_url_mutex_)
   enum class OtaUrlState { kIdle, kDownloading, kDone, kFailed };

--- a/main/include/printsphere/ui.hpp
+++ b/main/include/printsphere/ui.hpp
@@ -47,7 +47,9 @@ class Ui {
   void update_power_save(bool on_battery, bool keep_awake, bool print_active);
   void set_battery_display_policy(const BatteryDisplayPolicy& policy);
   bool is_low_power_mode_active() const;
-  ScreenPowerMode screen_power_mode() const { return screen_power_mode_; }
+  ScreenPowerMode screen_power_mode() const {
+    return screen_power_mode_.load(std::memory_order_relaxed);
+  }
   bool is_config_page_active() const {
     return !page_scrolling_snapshot_.load(std::memory_order_relaxed) &&
            active_page_snapshot_.load(std::memory_order_relaxed) == kPageIdxPrinterSelect;
@@ -169,7 +171,7 @@ class Ui {
   };
   std::vector<PrinterCardWidgets> page0_cards_;
   std::vector<PrinterCardInfo>    last_printer_cards_;  // change-detection cache
-  int pending_printer_switch_ = -1;
+  std::atomic<int> pending_printer_switch_{-1};
 
   void rebuild_printer_cards_locked(const std::vector<PrinterCardInfo>& cards);
   void replay_card_animations_locked();
@@ -258,8 +260,8 @@ class Ui {
   lv_obj_t* portal_overlay_value_ = nullptr;
   lv_obj_t* portal_overlay_detail_ = nullptr;
   lv_timer_t* ring_anim_timer_ = nullptr;  // unused, ambient sweep timer removed
-  int user_brightness_percent_ = 80;
-  int applied_brightness_percent_ = -1;
+  std::atomic<int> user_brightness_percent_{80};
+  std::atomic<int> applied_brightness_percent_{-1};
   bool gesture_active_ = false;
   bool overlay_visible_ = false;
   bool scrolling_ = false;
@@ -302,7 +304,8 @@ class Ui {
   uint32_t last_ring_text_hex_ = UINT32_MAX;
   uint32_t last_rendered_ams_signature_ = UINT32_MAX;
   std::atomic<uint32_t> last_activity_tick_ms_{0};
-  ScreenPowerMode screen_power_mode_ = ScreenPowerMode::kAwake;
+  std::atomic<ScreenPowerMode> screen_power_mode_{ScreenPowerMode::kAwake};
+  std::atomic<bool> wake_display_requested_{false};
   std::string last_ui_status_;
   bool last_print_active_ = false;
   std::string last_diag_status_;
@@ -340,6 +343,7 @@ class Ui {
   PrinterSnapshot deferred_snapshot_{};
   PrinterSnapshot last_snapshot_{};
   DisplayRotation display_rotation_ = DisplayRotation::k0;
+  mutable std::mutex battery_display_policy_mutex_{};
   BatteryDisplayPolicy battery_display_policy_{};
 };
 

--- a/main/src/application.cpp
+++ b/main/src/application.cpp
@@ -361,24 +361,30 @@ void Application::run() {
       cloud_client_.configure(config_store_.load_cloud_credentials(), new_conn.serial);
       ESP_LOGI(kTag, "Switched active printer to profile %d", switch_idx);
     }
-    if (ui_.is_config_page_active()) {
-      const auto profiles = config_store_.load_printer_profiles();
-      const uint8_t active_idx = config_store_.load_active_printer_index();
+    const bool config_page_active = ui_.is_config_page_active();
+    if (config_page_active) {
       const bool local_connected = printer_client_.snapshot().local_connected;
-      std::vector<Ui::PrinterCardInfo> cards;
-      cards.reserve(profiles.size());
-      for (const auto& p : profiles) {
-        Ui::PrinterCardInfo ci;
-        ci.index = p.index;
-        ci.name = p.display_name;
-        ci.model = p.model;
-        ci.host = p.host;
-        ci.active = (p.index == active_idx);
-        ci.connected = ci.active && local_connected;
-        cards.push_back(std::move(ci));
+      if (!last_config_page_active_ || local_connected != last_config_local_connected_ ||
+          switch_idx >= 0) {
+        const auto profiles = config_store_.load_printer_profiles();
+        const uint8_t active_idx = config_store_.load_active_printer_index();
+        std::vector<Ui::PrinterCardInfo> cards;
+        cards.reserve(profiles.size());
+        for (const auto& p : profiles) {
+          Ui::PrinterCardInfo ci;
+          ci.index = p.index;
+          ci.name = p.display_name;
+          ci.model = p.model;
+          ci.host = p.host;
+          ci.active = (p.index == active_idx);
+          ci.connected = ci.active && local_connected;
+          cards.push_back(std::move(ci));
+        }
+        ui_.update_printer_cards(cards);
       }
-      ui_.update_printer_cards(cards);
+      last_config_local_connected_ = local_connected;
     }
+    last_config_page_active_ = config_page_active;
     const PortalAccessSnapshot portal_access = setup_portal_.access_snapshot();
     const bool wifi_connected = wifi_manager_.is_station_connected();
     const std::string wifi_ip = wifi_manager_.station_ip();

--- a/main/src/bambu_cloud_client.cpp
+++ b/main/src/bambu_cloud_client.cpp
@@ -27,6 +27,7 @@
 #include "esp_timer.h"
 #include "esp_wifi.h"
 #include "mbedtls/base64.h"
+#include "mbedtls/ssl.h"
 
 namespace printsphere {
 
@@ -64,6 +65,7 @@ constexpr int64_t kCloudAuthRetryBackoffUs =
     static_cast<int64_t>(kCloudAuthRetryBackoffSeconds) * 1000000LL;
 constexpr uint64_t kCloudLiveDataFreshMs = 120000ULL;
 constexpr uint64_t kCloudOptimisticLightMs = 8000ULL;
+constexpr int64_t kCloudIoRetryDeadlineUs = 10000000LL;
 constexpr size_t kMaxCloudMqttPayloadBytes = 64U * 1024U;
 constexpr size_t kMaxJsonResponseBytes = 96U * 1024U;
 constexpr int kCloudPrintErrorTaskCanceled = 0x0300400C;
@@ -311,6 +313,60 @@ struct ParsedHttpsUrl {
   std::string target;
   int port = 443;
 };
+
+bool http_client_write_all(esp_http_client_handle_t client, const std::string& body) {
+  size_t offset = 0;
+  const int64_t deadline_us = esp_timer_get_time() + kCloudIoRetryDeadlineUs;
+  while (offset < body.size()) {
+    if (esp_timer_get_time() >= deadline_us) {
+      return false;
+    }
+    const int written = esp_http_client_write(
+        client, body.data() + offset, static_cast<int>(body.size() - offset));
+    if (written <= 0) {
+      return false;
+    }
+    offset += static_cast<size_t>(written);
+  }
+  return true;
+}
+
+bool tls_write_all(esp_tls_t* tls, const std::string& data) {
+  size_t offset = 0;
+  const int64_t deadline_us = esp_timer_get_time() + kCloudIoRetryDeadlineUs;
+  while (offset < data.size()) {
+    if (esp_timer_get_time() >= deadline_us) {
+      return false;
+    }
+    const ssize_t written = esp_tls_conn_write(tls, data.data() + offset, data.size() - offset);
+    if (written == MBEDTLS_ERR_SSL_WANT_WRITE || written == MBEDTLS_ERR_SSL_WANT_READ) {
+      vTaskDelay(pdMS_TO_TICKS(10));
+      continue;
+    }
+    if (written <= 0) {
+      return false;
+    }
+    offset += static_cast<size_t>(written);
+  }
+  return true;
+}
+
+ssize_t tls_read_with_retry(esp_tls_t* tls, void* buffer, size_t length,
+                            int64_t deadline_us) {
+  while (esp_timer_get_time() < deadline_us) {
+    const ssize_t read = esp_tls_conn_read(tls, buffer, length);
+    if (read == MBEDTLS_ERR_SSL_WANT_READ || read == MBEDTLS_ERR_SSL_WANT_WRITE) {
+      vTaskDelay(pdMS_TO_TICKS(10));
+      continue;
+    }
+    return read;
+  }
+  return -1;
+}
+
+bool tick_deadline_active(TickType_t deadline, TickType_t now) {
+  return deadline != 0 && static_cast<int32_t>(deadline - now) > 0;
+}
 
 std::string preview_cache_key(const std::string& url) {
   const std::string::size_type query_pos = url.find('?');
@@ -1437,6 +1493,8 @@ void merge_nozzle_temp_candidates(const cJSON* info_array, int active_nozzle_ind
   const int count = cJSON_GetArraySize(info_array);
   float first_temp = -1000.0f;
   float fallback_secondary = -1000.0f;
+  bool matched_active = false;
+  bool matched_secondary = false;
   for (int i = 0; i < count; ++i) {
     const cJSON* item = cJSON_GetArrayItem(info_array, i);
     if (!cJSON_IsObject(item)) {
@@ -1454,22 +1512,24 @@ void merge_nozzle_temp_candidates(const cJSON* info_array, int active_nozzle_ind
     }
 
     const int id = json_int_local(item, "id", -1);
-    if (id == active_nozzle_index) {
+    if (active_nozzle_index >= 0 && id == active_nozzle_index) {
       *active_temp = temp;
       *active_present = true;
-    } else if (id >= 0 && *secondary_temp <= 0.0f) {
+      matched_active = true;
+    } else if (active_nozzle_index >= 0 && id >= 0) {
       *secondary_temp = temp;
       *secondary_present = true;
-    } else if (fallback_secondary < -999.0f) {
+      matched_secondary = true;
+    } else if (active_nozzle_index >= 0 && fallback_secondary < -999.0f) {
       fallback_secondary = temp;
     }
   }
 
-  if (*active_temp <= 0.0f && first_temp > -999.0f) {
+  if (!matched_active && first_temp > -999.0f) {
     *active_temp = first_temp;
     *active_present = true;
   }
-  if (*secondary_temp <= 0.0f && fallback_secondary > -999.0f) {
+  if (!matched_secondary && fallback_secondary > -999.0f) {
     *secondary_temp = fallback_secondary;
     *secondary_present = true;
   }
@@ -1501,12 +1561,11 @@ NozzleTemperatureBundle extract_cloud_nozzle_temperature_bundle(const cJSON* ite
 
     const int active_nozzle_index = extract_active_nozzle_index(device);
     bundle.active_nozzle_index = active_nozzle_index;
-    const int merge_index = active_nozzle_index >= 0 ? active_nozzle_index : 0;
     merge_nozzle_temp_candidates(child_array_local(child_object_local(device, "nozzle"), "info"),
-                                 merge_index, &bundle.active, &bundle.active_present,
+                                 active_nozzle_index, &bundle.active, &bundle.active_present,
                                  &bundle.secondary, &bundle.secondary_present);
     merge_nozzle_temp_candidates(child_array_local(child_object_local(device, "extruder"), "info"),
-                                 merge_index, &bundle.active, &bundle.active_present,
+                                 active_nozzle_index, &bundle.active, &bundle.active_present,
                                  &bundle.secondary, &bundle.secondary_present);
   }
 
@@ -3613,7 +3672,7 @@ void BambuCloudClient::task_loop() {
     const bool preview_missing =
         preview_snapshot.preview_url.empty() || preview_snapshot.preview_blob == nullptr;
     const bool preview_backoff_active =
-        preview_retry_not_before_tick != 0 && now_tick < preview_retry_not_before_tick;
+        tick_deadline_active(preview_retry_not_before_tick, now_tick);
     const bool preview_due =
         preview_fetch_enabled && initial_preview_window_open &&
         !preview_backoff_active &&
@@ -3950,9 +4009,7 @@ bool BambuCloudClient::authenticate_with_tfa_code(const std::string& code) {
     return false;
   }
 
-  const int written =
-      esp_http_client_write(client, request_body.c_str(), static_cast<int>(request_body.size()));
-  if (written < 0) {
+  if (!http_client_write_all(client, request_body)) {
     ESP_LOGW(kTag, "HTTP write failed for TFA");
     esp_http_client_close(client);
     esp_http_client_cleanup(client);
@@ -4636,23 +4693,19 @@ std::shared_ptr<std::vector<uint8_t>> BambuCloudClient::download_preview_image(c
       "\r\nUser-Agent: PrintSphere/1.0\r\nAccept: image/png,image/*;q=0.9,*/*;q=0.1\r\n"
       "Accept-Encoding: identity\r\nConnection: close\r\n\r\n";
 
-  size_t written_total = 0;
-  while (written_total < request.size()) {
-    const ssize_t written =
-        esp_tls_conn_write(tls, request.data() + written_total, request.size() - written_total);
-    if (written <= 0) {
-      ESP_LOGW(kTag, "Preview TLS fallback write failed");
-      esp_tls_conn_destroy(tls);
-      return nullptr;
-    }
-    written_total += static_cast<size_t>(written);
+  if (!tls_write_all(tls, request)) {
+    ESP_LOGW(kTag, "Preview TLS fallback write failed");
+    esp_tls_conn_destroy(tls);
+    return nullptr;
   }
 
   std::vector<uint8_t> response;
   response.reserve(kPreviewPersistentReserveBytes);
   char read_buffer[1024];
+  const int64_t read_deadline_us = esp_timer_get_time() + 20000000LL;
   while (response.size() < (kMaxPreviewBytes + 8192)) {
-    const ssize_t read = esp_tls_conn_read(tls, read_buffer, sizeof(read_buffer));
+    const ssize_t read =
+        tls_read_with_retry(tls, read_buffer, sizeof(read_buffer), read_deadline_us);
     if (read > 0) {
       response.insert(response.end(), read_buffer, read_buffer + read);
       continue;
@@ -4780,9 +4833,7 @@ bool BambuCloudClient::perform_json_request(const std::string& url, const char* 
   }
 
   if (!request_body.empty()) {
-    const int written =
-        esp_http_client_write(client, request_body.c_str(), static_cast<int>(request_body.size()));
-    if (written < 0) {
+    if (!http_client_write_all(client, request_body)) {
       ESP_LOGW(kTag, "HTTP write failed for %s", url.c_str());
       esp_http_client_close(client);
       esp_http_client_cleanup(client);

--- a/main/src/config_store.cpp
+++ b/main/src/config_store.cpp
@@ -222,11 +222,18 @@ std::string ConfigStore::load_cloud_access_token() const {
 }
 
 SourceMode ConfigStore::load_source_mode() const {
+  const int cached = cached_source_mode_.load(std::memory_order_acquire);
+  if (cached >= static_cast<int>(SourceMode::kCloudOnly) &&
+      cached <= static_cast<int>(SourceMode::kHybrid)) {
+    return static_cast<SourceMode>(cached);
+  }
   std::string value = load_string("source_mode");
   if (value.empty()) {
     value = load_string("state_source");
   }
-  return parse_source_mode(value);
+  const SourceMode mode = parse_source_mode(value);
+  cached_source_mode_.store(static_cast<int>(mode), std::memory_order_release);
+  return mode;
 }
 
 DisplayRotation ConfigStore::load_display_rotation() const {
@@ -339,6 +346,7 @@ esp_err_t ConfigStore::clear_cloud_access_token() const {
 
 esp_err_t ConfigStore::save_source_mode(SourceMode mode) const {
   ESP_RETURN_ON_ERROR(save_string("source_mode", to_string(mode)), kTag, "save source mode failed");
+  cached_source_mode_.store(static_cast<int>(mode), std::memory_order_release);
   return save_string("state_source", "");
 }
 
@@ -470,6 +478,11 @@ std::string profile_key(uint8_t index, const char* suffix) {
   std::snprintf(key, sizeof(key), "prn_%u_%s", static_cast<unsigned>(index), suffix);
   return key;
 }
+
+esp_err_t set_nvs_string(nvs_handle_t handle, const std::string& key,
+                         const std::string& value) {
+  return nvs_set_str(handle, key.c_str(), value.c_str());
+}
 }  // namespace
 
 uint8_t ConfigStore::load_printer_profile_count() const {
@@ -515,26 +528,25 @@ esp_err_t ConfigStore::save_printer_profile(const PrinterProfile& profile) const
   std::lock_guard<std::mutex> lock(printer_profile_mutex_);
   const uint8_t idx = profile.index;
   if (idx >= kMaxPrinterProfiles) return ESP_ERR_INVALID_ARG;
-
-  ESP_RETURN_ON_ERROR(save_string(profile_key(idx, "ser").c_str(), profile.serial), kTag,
-                      "save profile serial");
-  ESP_RETURN_ON_ERROR(save_string(profile_key(idx, "host").c_str(), profile.host), kTag,
-                      "save profile host");
-  ESP_RETURN_ON_ERROR(save_string(profile_key(idx, "acc").c_str(), profile.access_code), kTag,
-                      "save profile access");
-  ESP_RETURN_ON_ERROR(save_string(profile_key(idx, "name").c_str(), profile.display_name), kTag,
-                      "save profile name");
-  ESP_RETURN_ON_ERROR(save_string(profile_key(idx, "mdl").c_str(), profile.model), kTag,
-                      "save profile model");
-  ESP_RETURN_ON_ERROR(save_string(profile_key(idx, "cld").c_str(), profile.cloud_bound ? "1" : "0"), kTag,
-                      "save profile cloud_bound");
-
   const uint8_t count = load_printer_profile_count();
-  if (idx >= count) {
-    ESP_RETURN_ON_ERROR(save_string("prn_count", std::to_string(idx + 1)), kTag,
-                        "save profile count");
+
+  nvs_handle_t handle = 0;
+  ESP_RETURN_ON_ERROR(nvs_open(kNamespace, NVS_READWRITE, &handle), kTag,
+                      "open profile storage");
+  esp_err_t err = set_nvs_string(handle, profile_key(idx, "ser"), profile.serial);
+  if (err == ESP_OK) err = set_nvs_string(handle, profile_key(idx, "host"), profile.host);
+  if (err == ESP_OK) err = set_nvs_string(handle, profile_key(idx, "acc"), profile.access_code);
+  if (err == ESP_OK) err = set_nvs_string(handle, profile_key(idx, "name"), profile.display_name);
+  if (err == ESP_OK) err = set_nvs_string(handle, profile_key(idx, "mdl"), profile.model);
+  if (err == ESP_OK) {
+    err = set_nvs_string(handle, profile_key(idx, "cld"), profile.cloud_bound ? "1" : "0");
   }
-  return ESP_OK;
+  if (err == ESP_OK && idx >= count) {
+    err = nvs_set_str(handle, "prn_count", std::to_string(idx + 1).c_str());
+  }
+  if (err == ESP_OK) err = nvs_commit(handle);
+  nvs_close(handle);
+  return err;
 }
 
 esp_err_t ConfigStore::delete_printer_profile(uint8_t index) const {
@@ -543,40 +555,53 @@ esp_err_t ConfigStore::delete_printer_profile(uint8_t index) const {
   const uint8_t count = load_printer_profile_count();
   if (index >= count) return ESP_ERR_NOT_FOUND;
 
-  // Shift all profiles above index down by one.
-  // Inline writes only — save_printer_profile() would re-acquire the mutex and deadlock.
+  struct StoredProfileFields {
+    std::string serial;
+    std::string host;
+    std::string access;
+    std::string name;
+    std::string model;
+    std::string cloud;
+  };
+  std::vector<StoredProfileFields> shifted;
+  shifted.reserve(count - index - 1);
   for (uint8_t i = index; i + 1 < count; ++i) {
-    const std::string serial = load_string(profile_key(i + 1, "ser").c_str());
-    const std::string host = load_string(profile_key(i + 1, "host").c_str());
-    const std::string access = load_string(profile_key(i + 1, "acc").c_str());
-    const std::string name = load_string(profile_key(i + 1, "name").c_str());
-    const std::string model = load_string(profile_key(i + 1, "mdl").c_str());
-    const std::string cloud = load_string(profile_key(i + 1, "cld").c_str());
-    save_string(profile_key(i, "ser").c_str(), serial);
-    save_string(profile_key(i, "host").c_str(), host);
-    save_string(profile_key(i, "acc").c_str(), access);
-    save_string(profile_key(i, "name").c_str(), name);
-    save_string(profile_key(i, "mdl").c_str(), model);
-    save_string(profile_key(i, "cld").c_str(), cloud);
+    StoredProfileFields fields;
+    fields.serial = load_string(profile_key(i + 1, "ser").c_str());
+    fields.host = load_string(profile_key(i + 1, "host").c_str());
+    fields.access = load_string(profile_key(i + 1, "acc").c_str());
+    fields.name = load_string(profile_key(i + 1, "name").c_str());
+    fields.model = load_string(profile_key(i + 1, "mdl").c_str());
+    fields.cloud = load_string(profile_key(i + 1, "cld").c_str());
+    shifted.push_back(std::move(fields));
   }
-  // Clear the last slot
-  const uint8_t last = count - 1;
-  save_string(profile_key(last, "ser").c_str(), "");
-  save_string(profile_key(last, "host").c_str(), "");
-  save_string(profile_key(last, "acc").c_str(), "");
-  save_string(profile_key(last, "name").c_str(), "");
-  save_string(profile_key(last, "mdl").c_str(), "");
-  save_string(profile_key(last, "cld").c_str(), "");
-  save_string("prn_count", std::to_string(count - 1));
 
-  // Adjust active index if needed
   const uint8_t active = load_active_printer_index();
-  if (active == index) {
-    save_active_printer_index(0);
-  } else if (active > index && active > 0) {
-    save_active_printer_index(active - 1);
+  const uint8_t next_active = active == index ? 0 : (active > index ? active - 1 : active);
+  nvs_handle_t handle = 0;
+  ESP_RETURN_ON_ERROR(nvs_open(kNamespace, NVS_READWRITE, &handle), kTag,
+                      "open profile storage for delete");
+  esp_err_t err = ESP_OK;
+  for (size_t offset = 0; offset < shifted.size() && err == ESP_OK; ++offset) {
+    const uint8_t target = static_cast<uint8_t>(index + offset);
+    const StoredProfileFields& fields = shifted[offset];
+    err = set_nvs_string(handle, profile_key(target, "ser"), fields.serial);
+    if (err == ESP_OK) err = set_nvs_string(handle, profile_key(target, "host"), fields.host);
+    if (err == ESP_OK) err = set_nvs_string(handle, profile_key(target, "acc"), fields.access);
+    if (err == ESP_OK) err = set_nvs_string(handle, profile_key(target, "name"), fields.name);
+    if (err == ESP_OK) err = set_nvs_string(handle, profile_key(target, "mdl"), fields.model);
+    if (err == ESP_OK) err = set_nvs_string(handle, profile_key(target, "cld"), fields.cloud);
   }
-  return ESP_OK;
+
+  const uint8_t last = count - 1;
+  for (const char* suffix : {"ser", "host", "acc", "name", "mdl", "cld"}) {
+    if (err == ESP_OK) err = set_nvs_string(handle, profile_key(last, suffix), "");
+  }
+  if (err == ESP_OK) err = nvs_set_str(handle, "prn_count", std::to_string(count - 1).c_str());
+  if (err == ESP_OK) err = nvs_set_str(handle, "prn_active", std::to_string(next_active).c_str());
+  if (err == ESP_OK) err = nvs_commit(handle);
+  nvs_close(handle);
+  return err;
 }
 
 PrinterProfile ConfigStore::load_active_printer_profile() const {

--- a/main/src/p1s_camera_client.cpp
+++ b/main/src/p1s_camera_client.cpp
@@ -14,6 +14,7 @@
 #include "esp_memory_utils.h"
 #include "esp_timer.h"
 #include "esp_tls.h"
+#include "mbedtls/ssl.h"
 
 namespace printsphere {
 
@@ -243,6 +244,10 @@ bool P1sCameraClient::read_exact(esp_tls_t* tls, void* buffer, size_t length) {
       return false;
     }
     const ssize_t read = esp_tls_conn_read(tls, out + offset, length - offset);
+    if (read == MBEDTLS_ERR_SSL_WANT_READ || read == MBEDTLS_ERR_SSL_WANT_WRITE) {
+      vTaskDelay(pdMS_TO_TICKS(10));
+      continue;
+    }
     if (read <= 0) {
       return false;
     }
@@ -260,6 +265,10 @@ bool P1sCameraClient::write_all(esp_tls_t* tls, const void* buffer, size_t lengt
       return false;
     }
     const ssize_t written = esp_tls_conn_write(tls, data + offset, length - offset);
+    if (written == MBEDTLS_ERR_SSL_WANT_WRITE || written == MBEDTLS_ERR_SSL_WANT_READ) {
+      vTaskDelay(pdMS_TO_TICKS(10));
+      continue;
+    }
     if (written <= 0) {
       return false;
     }

--- a/main/src/printer_client.cpp
+++ b/main/src/printer_client.cpp
@@ -829,6 +829,8 @@ void merge_nozzle_temp_candidates(const cJSON* info_array, int active_nozzle_ind
   const int count = cJSON_GetArraySize(info_array);
   float first_temp = -1000.0f;
   float fallback_secondary = -1000.0f;
+  bool matched_active = false;
+  bool matched_secondary = false;
   for (int i = 0; i < count; ++i) {
     const cJSON* item = cJSON_GetArrayItem(info_array, i);
     if (!cJSON_IsObject(item)) {
@@ -847,19 +849,25 @@ void merge_nozzle_temp_candidates(const cJSON* info_array, int active_nozzle_ind
       first_temp = temp;
     }
 
-    if (id == active_nozzle_index) {
+    if (active_nozzle_index >= 0 && id == active_nozzle_index) {
       *active_temp = temp;
-    } else if (id >= 0 && *secondary_temp <= 0.0f) {
+      matched_active = true;
+    } else if (active_nozzle_index >= 0 && id >= 0) {
       *secondary_temp = temp;
-    } else if (fallback_secondary < -999.0f) {
+      matched_secondary = true;
+    } else if (active_nozzle_index >= 0 && fallback_secondary < -999.0f) {
       fallback_secondary = temp;
     }
   }
 
-  if (*active_temp <= 0.0f && first_temp > -999.0f) {
+  // Do not use the previous runtime temperature to decide whether this payload
+  // is allowed to update it. Some V2 payloads omit an id (or use an id other
+  // than zero for a single nozzle), so the first fresh sample is the active
+  // hotend when no explicit active-id match was found.
+  if (!matched_active && first_temp > -999.0f) {
     *active_temp = first_temp;
   }
-  if (*secondary_temp <= 0.0f && fallback_secondary > -999.0f) {
+  if (!matched_secondary && fallback_secondary > -999.0f) {
     *secondary_temp = fallback_secondary;
   }
 }
@@ -917,10 +925,9 @@ NozzleTemperatureBundle extract_nozzle_temperature_bundle(const cJSON* print, fl
   const cJSON* extruder = child_object_local(device, "extruder");
   const int active_nozzle_index = extract_active_nozzle_index(device);
   bundle.active_nozzle_index = active_nozzle_index;
-  const int merge_index = active_nozzle_index >= 0 ? active_nozzle_index : 0;
   merge_nozzle_temp_candidates(child_array_local(child_object_local(device, "nozzle"), "info"),
-                               merge_index, &bundle.active, &bundle.secondary);
-  merge_nozzle_temp_candidates(child_array_local(extruder, "info"), merge_index,
+                               active_nozzle_index, &bundle.active, &bundle.secondary);
+  merge_nozzle_temp_candidates(child_array_local(extruder, "info"), active_nozzle_index,
                                &bundle.active, &bundle.secondary);
   ESP_LOGD(kTag, "[DBG] nozzle bundle final: active=%.1f secondary=%.1f active_nozzle_idx=%d",
            bundle.active, bundle.secondary, active_nozzle_index);

--- a/main/src/setup_portal.cpp
+++ b/main/src/setup_portal.cpp
@@ -76,6 +76,44 @@ std::string json_escape(const std::string& input) {
   return output;
 }
 
+std::string html_escape(const std::string& input) {
+  std::string output;
+  output.reserve(input.size());
+  for (const char ch : input) {
+    switch (ch) {
+      case '&': output += "&amp;"; break;
+      case '<': output += "&lt;"; break;
+      case '>': output += "&gt;"; break;
+      case '"': output += "&quot;"; break;
+      case '\'': output += "&#39;"; break;
+      default: output.push_back(ch); break;
+    }
+  }
+  return output;
+}
+
+// Escapes a value placed inside a quoted JavaScript string in an inline
+// <script>. Escaping '<' prevents a value containing "</script>" from ending
+// the element before the JavaScript parser sees the string literal.
+std::string script_string_escape(const std::string& input) {
+  std::string output;
+  output.reserve(input.size());
+  for (const unsigned char ch : input) {
+    switch (ch) {
+      case '\\': output += "\\\\"; break;
+      case '"': output += "\\\""; break;
+      case '\n': output += "\\n"; break;
+      case '\r': output += "\\r"; break;
+      case '\t': output += "\\t"; break;
+      case '<': output += "\\u003C"; break;
+      case '>': output += "\\u003E"; break;
+      case '&': output += "\\u0026"; break;
+      default: output.push_back(static_cast<char>(ch)); break;
+    }
+  }
+  return output;
+}
+
 std::string read_string_field(const cJSON* object, const char* key) {
   const cJSON* item = cJSON_GetObjectItemCaseSensitive(object, key);
   if (!cJSON_IsString(item) || item->valuestring == nullptr) {
@@ -985,7 +1023,7 @@ esp_err_t SetupPortal::send_unlock_page(httpd_req_t* request) {
   html += ".status{margin:10px 0 0;color:#f0a64b;font-weight:700;}.micro{margin-top:18px;font-size:14px;color:#94a3b8;}</style></head><body><main class=\"card\">";
   html += "<h1>Portal Locked</h1>";
   html += "<p id=\"detail\">";
-  html += json_escape(access.detail);
+  html += html_escape(access.detail);
   html += "</p>";
   html += "<form id=\"unlock-form\"><label for=\"pin\">Unlock PIN</label><input id=\"pin\" inputmode=\"numeric\" autocomplete=\"one-time-code\" maxlength=\"6\" placeholder=\"000000\">";
   html += "<button type=\"submit\" id=\"unlock-button\">Unlock Web Config</button></form>";
@@ -1451,6 +1489,7 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
       bat_policy.dim_enabled || bat_policy.screen_off_enabled ? "info" : "idle";
   const PowerSnapshot power = portal->pmu_manager_.sample();
   std::string html;
+  html.reserve(48U * 1024U);
 
   const auto add_badge = [](std::string* html, const char* id, const std::string& label,
                             const std::string& value, const char* state_class) {
@@ -1465,7 +1504,7 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
     *html += "><span class=\"badge-label\">";
     *html += label;
     *html += "</span><span class=\"badge-value\">";
-    *html += json_escape(value);
+    *html += html_escape(value);
     *html += "</span></div>";
   };
   const auto add_summary_pill = [](std::string* html, const std::string& value,
@@ -1479,7 +1518,7 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
       *html += "\"";
     }
     *html += ">";
-    *html += json_escape(value);
+    *html += html_escape(value);
     *html += "</span>";
   };
   const auto begin_collapsible_section =
@@ -1627,7 +1666,7 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
 
   html += "<section class=\"hero\">";
   html += "<div class=\"hero-top\"><div class=\"hero-brand\"><div class=\"eyebrow\">PrintSphere</div><a class=\"hero-version\" href=\"https://github.com/cptkirki/PrintSphere\" target=\"_blank\" rel=\"noopener noreferrer\">";
-  html += json_escape(kPortalReleaseVersion);
+  html += html_escape(kPortalReleaseVersion);
   html += "</a></div><div id=\"portal-timer\" style=\"display:none\" title=\"Click to extend session by 5 minutes\"></div></div>";
   html += "<h1 class=\"title\">Web Config</h1>";
   html += "<p class=\"subtitle\">";
@@ -1659,14 +1698,14 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
     html += "<div class=\"actions\"><button type=\"button\" class=\"secondary\" id=\"wifi-scan-button\">Scan Networks</button>";
     html += "<div class=\"micro\" id=\"wifi-scan-detail\">Scan for visible networks or type an SSID manually.</div></div>";
     html += "<div class=\"field\" id=\"wifi-ssid-manual-field\"><label for=\"wifi_ssid\">Wi-Fi SSID</label><input id=\"wifi_ssid\" value=\"";
-    html += json_escape(wifi.ssid);
+    html += html_escape(wifi.ssid);
     html += "\" autocomplete=\"off\"></div>";
     html += "<div class=\"field\" id=\"wifi-ssid-scan-field\" style=\"display:none\"><label for=\"wifi_ssid_select\">Detected Networks</label><select id=\"wifi_ssid_select\"><option value=\"\">Select detected Wi-Fi...</option></select></div>";
     html += "<div class=\"field\"><label for=\"wifi_password\">Wi-Fi Password</label><input id=\"wifi_password\" type=\"password\" value=\"\" placeholder=\"";
-    html += json_escape(wifi_password_placeholder);
+    html += html_escape(wifi_password_placeholder);
     html += "\" autocomplete=\"off\"></div>";
     html += "<p class=\"micro\">Current network status: <span id=\"wifi-detail\">";
-    html += json_escape(wifi_badge_value);
+    html += html_escape(wifi_badge_value);
     html += "</span></p>";
     end_collapsible_section();
   };
@@ -1677,10 +1716,10 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
         cloud_badge_value, cloud_badge_class, cloud_section_open, "cloud-section-pill");
     html += "<div class=\"grid-2\">";
     html += "<div class=\"field\"><label for=\"cloud_email\">Bambu Email / Phone</label><input id=\"cloud_email\" value=\"";
-    html += json_escape(cloud.email);
+    html += html_escape(cloud.email);
     html += "\" autocomplete=\"username\"></div>";
     html += "<div class=\"field\"><label for=\"cloud_password\">Bambu Password</label><input id=\"cloud_password\" type=\"password\" value=\"\" placeholder=\"";
-    html += json_escape(cloud_password_placeholder);
+    html += html_escape(cloud_password_placeholder);
     html += "\" autocomplete=\"current-password\"></div>";
     html += "</div>";
     html += "<div class=\"field\"><label for=\"cloud_region\">Cloud Region</label><select id=\"cloud_region\">";
@@ -1700,15 +1739,15 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
     }
     html += ">CN</option></select></div>";
     html += "<div class=\"hint-box\"><strong>Printer Status:</strong> <span id=\"cloud-detail\">";
-    html += json_escape(cloud_snapshot.detail);
+    html += html_escape(cloud_snapshot.detail);
     html += "</span><div class=\"micro\" id=\"mqtt-cloud-telemetry\" style=\"margin-top:4px;color:#666;\"></div></div>";
     html += "<div class=\"actions\"><button type=\"button\" class=\"secondary\" id=\"cloud-connect-button\">Connect Cloud</button>";
     html += "<div class=\"micro\">This saves the cloud credentials immediately. In Hybrid and Cloud only it also starts the login without rebooting.</div></div>";
     html += "<div class=\"grid-2\">";
     html += "<div class=\"field\"><label for=\"cloud_verification_code\" id=\"cloud-verification-label\">";
-    html += json_escape(cloud_code_label);
+    html += html_escape(cloud_code_label);
     html += "</label><input id=\"cloud_verification_code\" value=\"\" autocomplete=\"one-time-code\" placeholder=\"";
-    html += json_escape(cloud_code_placeholder);
+    html += html_escape(cloud_code_placeholder);
     html += "\"></div>";
     html += "<div class=\"field\"><label>&nbsp;</label><button type=\"button\" class=\"secondary\" id=\"verify-button\">Submit Code</button></div>";
     html += "</div>";
@@ -1717,7 +1756,7 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
       html += " hidden";
     }
     html += "\" id=\"cloud-verify-note\">";
-    html += json_escape(cloud_code_note);
+    html += html_escape(cloud_code_note);
     html += "</p>";
     end_collapsible_section();
   };
@@ -1728,17 +1767,17 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
         local_badge_value, local_badge_class, local_section_open, "local-section-pill");
     html += "<div class=\"grid-2\">";
     html += "<div class=\"field\"><label for=\"printer_host\">Printer IP or Hostname</label><input id=\"printer_host\" value=\"";
-    html += json_escape(printer.host);
+    html += html_escape(printer.host);
     html += "\" autocomplete=\"off\"></div>";
     html += "<div class=\"field\"><label for=\"printer_serial\">Printer Serial Number</label><input id=\"printer_serial\" value=\"";
-    html += json_escape(effective_printer_serial);
+    html += html_escape(effective_printer_serial);
     html += "\" autocomplete=\"off\"></div>";
     html += "</div>";
     html += "<div class=\"field\"><label for=\"printer_access_code\">Access Code</label><input id=\"printer_access_code\" type=\"password\" value=\"\" placeholder=\"";
-    html += json_escape(printer_access_code_placeholder);
+    html += html_escape(printer_access_code_placeholder);
     html += "\" autocomplete=\"off\"></div>";
     html += "<div class=\"hint-box\"><strong>Local Status:</strong> <span id=\"local-detail\">";
-    html += json_escape(local_snapshot.detail);
+    html += html_escape(local_snapshot.detail);
     html += "</span><div class=\"micro\" id=\"mqtt-local-telemetry\" style=\"margin-top:4px;color:#666;\"></div></div>";
     html += "<div class=\"actions\"><button type=\"button\" class=\"secondary\" id=\"local-connect-button\">Connect Local</button>";
     html += "<div class=\"micro\">This saves the local printer credentials immediately. In Hybrid and Local only it also reconnects MQTT and camera without rebooting.</div></div>";
@@ -1793,7 +1832,7 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
     html += "<div class=\"actions\"><button type=\"button\" class=\"primary hidden\" id=\"display-rotation-apply-button\">Apply + Restart</button>";
     html += "<div class=\"micro hidden\" id=\"display-rotation-apply-hint\">The new panel orientation is applied on the next boot so display and touch stay in sync.</div></div>";
     html += "<p class=\"micro\">Current orientation: ";
-    html += json_escape(display_rotation_badge_value(display_rotation));
+    html += html_escape(display_rotation_badge_value(display_rotation));
     html += "</p>";
     end_settings_panel();
 
@@ -2186,18 +2225,18 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
       html += "\" data-index=\"";
       html += std::to_string(p.index);
       html += "\" data-serial=\"";
-      html += json_escape(p.serial);
+      html += html_escape(p.serial);
       html += "\">";
       html += "<div class=\"printer-card-header\">";
       html += "<input type=\"text\" class=\"printer-name-input\" data-index=\"";
       html += std::to_string(p.index);
       html += "\" data-serial=\"";
-      html += json_escape(p.serial);
+      html += html_escape(p.serial);
       html += "\" value=\"";
       const std::string card_name = p.display_name.empty()
           ? (!p.model.empty() ? p.model : ("Printer " + std::to_string(p.index + 1)))
           : p.display_name;
-      html += json_escape(card_name);
+      html += html_escape(card_name);
       html += "\" placeholder=\"Profile name\">";
       html += "<span class=\"summary-pill ";
       html += is_active ? "ok" : "idle";
@@ -2207,12 +2246,12 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
       html += "<div class=\"printer-card-body\">";
       if (!p.model.empty()) {
         html += "<span class=\"printer-tag\">";
-        html += json_escape(p.model);
+        html += html_escape(p.model);
         html += "</span>";
       }
       if (p.has_local_config()) {
         html += "<span class=\"printer-tag\">Local: ";
-        html += json_escape(p.host);
+        html += html_escape(p.host);
         html += "</span>";
       }
       if (has_cloud) {
@@ -2220,7 +2259,7 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
       }
       if (!p.serial.empty()) {
         html += "<span class=\"printer-tag\">";
-        html += json_escape(p.serial.substr(0, 6) + "...");
+        html += html_escape(p.serial.substr(0, 6) + "...");
         html += "</span>";
       }
       html += "</div>";
@@ -2247,10 +2286,10 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
       }
       if (already_saved) continue;
       html += "<div class=\"printer-card cloud-only\" data-serial=\"";
-      html += json_escape(cd.serial);
+      html += html_escape(cd.serial);
       html += "\">";
       html += "<div class=\"printer-card-header\"><strong>";
-      html += json_escape(cd.display_name.empty() ? to_string(cd.model) : cd.display_name);
+      html += html_escape(cd.display_name.empty() ? to_string(cd.model) : cd.display_name);
       html += "</strong><span class=\"summary-pill info\">Cloud only</span></div>";
       html += "<div class=\"printer-card-body\">";
       html += "<span class=\"printer-tag\">";
@@ -2260,13 +2299,13 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
       html += cd.online ? "Online" : "Offline";
       html += "</span>";
       html += "<span class=\"printer-tag\">";
-      html += json_escape(cd.serial.substr(0, 6) + "...");
+      html += html_escape(cd.serial.substr(0, 6) + "...");
       html += "</span></div>";
       html += "<div class=\"printer-card-actions\">";
       html += "<button type=\"button\" class=\"secondary printer-add-cloud-btn\" data-serial=\"";
-      html += json_escape(cd.serial);
+      html += html_escape(cd.serial);
       html += "\" data-name=\"";
-      html += json_escape(cd.display_name);
+      html += html_escape(cd.display_name);
       html += "\" data-model=\"";
       html += to_string(cd.model);
       html += "\">Add to Profiles</button></div></div>";
@@ -2383,16 +2422,16 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
   html += "<section class=\"footer-card\">";
   html += "<div class=\"actions\">";
   html += "<button type=\"submit\" class=\"primary\" id=\"save-button\">";
-  html += json_escape(save_button_label);
+  html += html_escape(save_button_label);
   html += "</button>";
   html += "<div class=\"micro\">";
-  html += json_escape(save_button_hint);
+  html += html_escape(save_button_hint);
   html += "</div>";
   html += "</div>";
   html += "<div class=\"status-line\" id=\"status\">";
-  html += json_escape(initial_status_line);
+  html += html_escape(initial_status_line);
   html += "</div><div class=\"status-detail\" id=\"status-detail\">";
-  html += json_escape(initial_status_detail);
+  html += html_escape(initial_status_detail);
   html += "</div>";
   html += "</section>";
   html += "</form>";
@@ -2465,9 +2504,9 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
   html += "let wifiScanInFlight=false;";
   html += "document.querySelectorAll('.settings-accordion').forEach(group=>{group.querySelectorAll('.settings-panel').forEach(panel=>{panel.addEventListener('toggle',()=>{if(!panel.open)return;group.querySelectorAll('.settings-panel').forEach(other=>{if(other!==panel)other.open=false;});});});});";
   html += "const savedConfig={cloud_email:\"";
-  html += json_escape(cloud.email);
+  html += script_string_escape(cloud.email);
   html += "\",cloud_region:\"";
-  html += json_escape(to_string(cloud.region));
+  html += script_string_escape(to_string(cloud.region));
   html += "\",source_mode:\"";
   html += to_string(source_mode);
   html += "\",display_rotation:\"";
@@ -2475,9 +2514,9 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
   html += "\",portal_lock_enabled:";
   html += portal_lock_enabled ? "true" : "false";
   html += ",printer_host:\"";
-  html += json_escape(printer.host);
+  html += script_string_escape(printer.host);
   html += "\",printer_serial:\"";
-  html += json_escape(effective_printer_serial);
+  html += script_string_escape(effective_printer_serial);
   html += "\",wifi_password_saved:";
   html += wifi_password_saved ? "true" : "false";
   html += ",cloud_password_saved:";
@@ -2505,7 +2544,7 @@ esp_err_t SetupPortal::handle_root(httpd_req_t* request) {
   html += ",filament_anim:";
   html += filament_anim ? "true" : "false";
   html += ",tz_iana:\"";
-  html += json_escape(portal->config_store_.load_timezone_iana());
+  html += script_string_escape(portal->config_store_.load_timezone_iana());
   html += "\"";
   html += "};";
   html += "function setStatus(line,detail,lockMs){statusEl.textContent=line||'';statusDetailEl.textContent=detail||'';"
@@ -3606,9 +3645,11 @@ esp_err_t SetupPortal::handle_config_post(httpd_req_t* request) {
   ESP_RETURN_ON_ERROR(portal->config_store_.save_battery_display_policy(bat_policy_post), kTag,
                       "save battery display policy failed");
 
-  if (!portal->reboot_requested_) {
-    portal->reboot_requested_ = true;
-    xTaskCreate(&SetupPortal::reboot_task, "portal_reboot", 2048, portal, 4, nullptr);
+  if (!portal->schedule_reboot()) {
+    httpd_resp_set_status(request, "503 Service Unavailable");
+    send_json(request,
+              "{\"status\":\"saved\",\"rebooting\":false,\"detail\":\"Settings were saved, but the restart task could not be started. Restart the device manually.\"}");
+    return ESP_OK;
   }
 
   send_json(request, "{\"status\":\"saved\",\"rebooting\":true}");
@@ -3687,9 +3728,11 @@ esp_err_t SetupPortal::handle_source_mode_post(httpd_req_t* request) {
   ESP_RETURN_ON_ERROR(portal->config_store_.save_source_mode(source_mode), kTag,
                       "save source mode failed");
 
-  if (!portal->reboot_requested_) {
-    portal->reboot_requested_ = true;
-    xTaskCreate(&SetupPortal::reboot_task, "portal_reboot", 2048, portal, 4, nullptr);
+  if (!portal->schedule_reboot()) {
+    httpd_resp_set_status(request, "503 Service Unavailable");
+    send_json(request,
+              "{\"status\":\"saved\",\"rebooting\":false,\"detail\":\"Connection mode was saved, but the restart task could not be started.\"}");
+    return ESP_OK;
   }
 
   send_json(request, "{\"status\":\"saved\",\"rebooting\":true}");
@@ -3718,9 +3761,11 @@ esp_err_t SetupPortal::handle_display_rotation_post(httpd_req_t* request) {
   ESP_RETURN_ON_ERROR(portal->config_store_.save_display_rotation(rotation), kTag,
                       "save display rotation failed");
 
-  if (!portal->reboot_requested_) {
-    portal->reboot_requested_ = true;
-    xTaskCreate(&SetupPortal::reboot_task, "portal_reboot", 2048, portal, 4, nullptr);
+  if (!portal->schedule_reboot()) {
+    httpd_resp_set_status(request, "503 Service Unavailable");
+    send_json(request,
+              "{\"status\":\"saved\",\"rebooting\":false,\"detail\":\"Display rotation was saved, but the restart task could not be started.\"}");
+    return ESP_OK;
   }
 
   send_json(request, "{\"status\":\"saved\",\"rebooting\":true}");
@@ -3779,9 +3824,11 @@ esp_err_t SetupPortal::handle_battery_display_post(httpd_req_t* request) {
   ESP_RETURN_ON_ERROR(portal->config_store_.save_battery_display_policy(policy), kTag,
                       "save battery display policy failed");
 
-  if (!portal->reboot_requested_) {
-    portal->reboot_requested_ = true;
-    xTaskCreate(&SetupPortal::reboot_task, "portal_reboot", 2048, portal, 4, nullptr);
+  if (!portal->schedule_reboot()) {
+    httpd_resp_set_status(request, "503 Service Unavailable");
+    send_json(request,
+              "{\"status\":\"saved\",\"rebooting\":false,\"detail\":\"Power settings were saved, but the restart task could not be started.\"}");
+    return ESP_OK;
   }
 
   send_json(request, "{\"status\":\"saved\",\"rebooting\":true}");
@@ -3812,9 +3859,11 @@ esp_err_t SetupPortal::handle_portal_access_post(httpd_req_t* request) {
   ESP_RETURN_ON_ERROR(portal->config_store_.save_portal_lock_enabled(portal_lock_enabled), kTag,
                       "save portal lock failed");
 
-  if (!portal->reboot_requested_) {
-    portal->reboot_requested_ = true;
-    xTaskCreate(&SetupPortal::reboot_task, "portal_reboot", 2048, portal, 4, nullptr);
+  if (!portal->schedule_reboot()) {
+    httpd_resp_set_status(request, "503 Service Unavailable");
+    send_json(request,
+              "{\"status\":\"saved\",\"rebooting\":false,\"detail\":\"Portal access was saved, but the restart task could not be started.\"}");
+    return ESP_OK;
   }
 
   send_json(request, "{\"status\":\"saved\",\"rebooting\":true}");
@@ -3849,9 +3898,11 @@ esp_err_t SetupPortal::handle_ams_display_post(httpd_req_t* request) {
   ESP_RETURN_ON_ERROR(portal->config_store_.save_filament_anim_enabled(filament_anim), kTag,
                       "save filament anim failed");
 
-  if (!portal->reboot_requested_) {
-    portal->reboot_requested_ = true;
-    xTaskCreate(&SetupPortal::reboot_task, "portal_reboot", 2048, portal, 4, nullptr);
+  if (!portal->schedule_reboot()) {
+    httpd_resp_set_status(request, "503 Service Unavailable");
+    send_json(request,
+              "{\"status\":\"saved\",\"rebooting\":false,\"detail\":\"AMS display settings were saved, but the restart task could not be started.\"}");
+    return ESP_OK;
   }
 
   send_json(request, "{\"status\":\"saved\",\"rebooting\":true}");
@@ -4075,23 +4126,34 @@ bool parse_wav_pcm(const uint8_t* data, size_t len, std::vector<int16_t>& sample
   size_t pcm_bytes = 0;
 
   size_t pos = 12;
-  while (pos + 8 <= len) {
+  while (pos <= len && len - pos >= 8) {
     uint32_t chunk_size = 0;
     std::memcpy(&chunk_size, data + pos + 4, 4);
+    const size_t available = len - pos - 8;
+    if (static_cast<size_t>(chunk_size) > available) {
+      error_out = "truncated WAV chunk";
+      return false;
+    }
     if (std::memcmp(data + pos, "fmt ", 4) == 0 && chunk_size >= 16) {
       std::memcpy(&audio_format, data + pos + 8, 2);
       std::memcpy(&channels, data + pos + 10, 2);
       std::memcpy(&sample_rate, data + pos + 12, 4);
       std::memcpy(&bits_per_sample, data + pos + 22, 2);
     } else if (std::memcmp(data + pos, "data", 4) == 0) {
-      if (pos + 8 <= len) {
-        pcm_data = data + pos + 8;
-        pcm_bytes = std::min(static_cast<size_t>(chunk_size), len - pos - 8);
-      }
+      pcm_data = data + pos + 8;
+      pcm_bytes = static_cast<size_t>(chunk_size);
     }
-    pos += 8 + chunk_size;
-    if (chunk_size & 1U) pos++;  // RIFF pads odd-length chunks to 2-byte boundary
-    if (pos == 0) break;  // guard against chunk_size wrap
+    const size_t padded_size = static_cast<size_t>(chunk_size) + (chunk_size & 1U);
+    if (padded_size > available) {
+      // A final odd-sized chunk may omit its optional RIFF padding byte.
+      if ((chunk_size & 1U) == 0U || static_cast<size_t>(chunk_size) != available) {
+        error_out = "truncated WAV padding";
+        return false;
+      }
+      pos = len;
+    } else {
+      pos += 8 + padded_size;
+    }
   }
 
   if (pcm_data == nullptr) { error_out = "data chunk not found"; return false; }
@@ -4846,16 +4908,28 @@ esp_err_t SetupPortal::handle_ota_upload(httpd_req_t* request) {
 
   ESP_LOGI(kTag, "OTA upload complete: %d bytes written, scheduling reboot", received);
   send_json(request, "{\"status\":\"success\",\"rebooting\":true}");
-  if (!portal->reboot_requested_) {
-    portal->reboot_requested_ = true;
-    xTaskCreate(&SetupPortal::reboot_task, "portal_reboot", 2048, portal, 4, nullptr);
-  }
+  portal->schedule_reboot();
   return ESP_OK;
 }
 
 void SetupPortal::reboot_task(void*) {
   vTaskDelay(pdMS_TO_TICKS(1500));
   esp_restart();
+}
+
+bool SetupPortal::schedule_reboot() {
+  bool expected = false;
+  if (!reboot_requested_.compare_exchange_strong(expected, true)) {
+    return true;
+  }
+  const BaseType_t created =
+      xTaskCreate(&SetupPortal::reboot_task, "portal_reboot", 2048, this, 4, nullptr);
+  if (created != pdPASS) {
+    reboot_requested_.store(false);
+    ESP_LOGE(kTag, "Failed to create reboot task");
+    return false;
+  }
+  return true;
 }
 
 esp_err_t SetupPortal::handle_ota_url(httpd_req_t* request) {
@@ -4919,7 +4993,19 @@ esp_err_t SetupPortal::handle_ota_url(httpd_req_t* request) {
   }
 
   ESP_LOGI(kTag, "Starting OTA URL task: %s", url.c_str());
-  xTaskCreate(&SetupPortal::ota_url_task, "ota_url", 8192, portal, 5, nullptr);
+  const BaseType_t created =
+      xTaskCreate(&SetupPortal::ota_url_task, "ota_url", 8192, portal, 5, nullptr);
+  if (created != pdPASS) {
+    {
+      std::lock_guard<std::mutex> lock(portal->ota_url_mutex_);
+      portal->ota_url_status_.state = OtaUrlState::kFailed;
+      portal->ota_url_status_.error = "Not enough memory to start OTA";
+    }
+    httpd_resp_set_status(request, "503 Service Unavailable");
+    send_json(request,
+              "{\"error\":\"OTA task unavailable\",\"detail\":\"Not enough memory to start the firmware download.\"}");
+    return ESP_OK;
+  }
 
   std::string body = "{\"status\":\"started\",\"url\":\"";
   body += json_escape(url);
@@ -5044,10 +5130,7 @@ void SetupPortal::ota_url_task(void* context) {
     portal->ota_url_status_.state = OtaUrlState::kDone;
     portal->ota_url_status_.progress_percent = 100;
   }
-  if (!portal->reboot_requested_) {
-    portal->reboot_requested_ = true;
-    xTaskCreate(&SetupPortal::reboot_task, "portal_reboot", 2048, portal, 4, nullptr);
-  }
+  portal->schedule_reboot();
   vTaskDelete(nullptr);
 }
 

--- a/main/src/ui.cpp
+++ b/main/src/ui.cpp
@@ -1299,9 +1299,9 @@ esp_err_t Ui::initialize() {
   ESP_RETURN_ON_ERROR(bsp_display_rotation_set(bsp_rotation_for(display_rotation_)), kTag,
                       "apply display rotation failed");
 
-  user_brightness_percent_ = -1;
-  applied_brightness_percent_ = -1;
-  screen_power_mode_ = ScreenPowerMode::kAwake;
+  user_brightness_percent_.store(-1, std::memory_order_relaxed);
+  applied_brightness_percent_.store(-1, std::memory_order_relaxed);
+  screen_power_mode_.store(ScreenPowerMode::kAwake, std::memory_order_relaxed);
   last_activity_tick_ms_.store(lv_tick_get());
   set_brightness_percent(kDefaultBrightnessPercent);
   ESP_RETURN_ON_ERROR(build_dashboard(), kTag, "build_dashboard failed");
@@ -1439,7 +1439,7 @@ void Ui::printer_card_click_cb(lv_event_t* event) {
   lv_obj_t* target = static_cast<lv_obj_t*>(lv_event_get_target(event));
   for (const auto& cw : self->page0_cards_) {
     if (cw.card == target) {
-      self->pending_printer_switch_ = cw.profile_index;
+      self->pending_printer_switch_.store(cw.profile_index, std::memory_order_release);
       self->note_activity(true);
 
       // Micro-interaction: quick scale bounce (100% → 91% → 100%)
@@ -1458,9 +1458,7 @@ void Ui::printer_card_click_cb(lv_event_t* event) {
 }
 
 int Ui::consume_printer_switch_request() {
-  int val = pending_printer_switch_;
-  pending_printer_switch_ = -1;
-  return val;
+  return pending_printer_switch_.exchange(-1, std::memory_order_acq_rel);
 }
 
 void Ui::apply_page0_parallax(bool force) {
@@ -3618,7 +3616,7 @@ void Ui::handle_screen_event(lv_event_t* event) {
 
   if (code == LV_EVENT_PRESSED) {
     set_pager_scroll_locked(false);
-    if (screen_power_mode_ == ScreenPowerMode::kOff) {
+    if (screen_power_mode_.load(std::memory_order_acquire) == ScreenPowerMode::kOff) {
       // First touch wakes the screen; a second touch performs UI actions.
       note_activity(true);
       gesture_active_ = false;
@@ -3633,7 +3631,7 @@ void Ui::handle_screen_event(lv_event_t* event) {
     overlay_visible_ = false;
     gesture_start_x_ = point.x;
     gesture_start_y_ = point.y;
-    gesture_start_brightness_ = user_brightness_percent_;
+    gesture_start_brightness_ = user_brightness_percent_.load(std::memory_order_acquire);
     return;
   }
 
@@ -3678,7 +3676,8 @@ void Ui::handle_screen_event(lv_event_t* event) {
     set_brightness_percent(new_brightness);
 
     char buffer[8] = {};
-    std::snprintf(buffer, sizeof(buffer), "%d%%", user_brightness_percent_);
+    std::snprintf(buffer, sizeof(buffer), "%d%%",
+                  user_brightness_percent_.load(std::memory_order_acquire));
     set_label_text_if_changed(brightness_overlay_, buffer);
     lv_obj_clear_flag(brightness_overlay_, LV_OBJ_FLAG_HIDDEN);
     overlay_visible_ = true;
@@ -3835,30 +3834,27 @@ void Ui::update_print_buttons_locked(const PrinterSnapshot& snapshot) {
 
 void Ui::set_brightness_percent(int brightness_percent) {
   const int clamped = std::clamp(brightness_percent, 0, 100);
-  if (user_brightness_percent_ == clamped) {
+  if (user_brightness_percent_.exchange(clamped, std::memory_order_acq_rel) == clamped) {
     return;
   }
-
-  user_brightness_percent_ = clamped;
   apply_brightness_policy();
 }
 
 void Ui::note_activity(bool wake_display_now) {
   last_activity_tick_ms_.store(lv_tick_get());
   if (wake_display_now) {
-    wake_display();
+    wake_display_requested_.store(true, std::memory_order_release);
   }
 }
 
 void Ui::wake_display() {
-  if (screen_power_mode_ == ScreenPowerMode::kAwake) {
+  const ScreenPowerMode previous =
+      screen_power_mode_.exchange(ScreenPowerMode::kAwake, std::memory_order_acq_rel);
+  if (previous == ScreenPowerMode::kAwake) {
     return;
   }
-
-  const bool was_off = screen_power_mode_ == ScreenPowerMode::kOff;
-  screen_power_mode_ = ScreenPowerMode::kAwake;
   apply_brightness_policy();
-  if (was_off) {
+  if (previous == ScreenPowerMode::kOff) {
     esp_lv_adapter_resume();
   }
 }
@@ -3868,26 +3864,33 @@ void Ui::request_wake_display() {
 }
 
 void Ui::set_battery_display_policy(const BatteryDisplayPolicy& policy) {
+  std::lock_guard<std::mutex> lock(battery_display_policy_mutex_);
   battery_display_policy_ = policy;
 }
 
 void Ui::apply_brightness_policy() {
-  int target_brightness = user_brightness_percent_;
-  if (screen_power_mode_ == ScreenPowerMode::kDimmed) {
-    if (battery_display_policy_.dim_brightness_percent > 0) {
-      target_brightness = std::clamp(battery_display_policy_.dim_brightness_percent, 1, 100);
+  const int user_brightness = user_brightness_percent_.load(std::memory_order_acquire);
+  const ScreenPowerMode power_mode = screen_power_mode_.load(std::memory_order_acquire);
+  int dim_brightness_percent = 0;
+  {
+    std::lock_guard<std::mutex> lock(battery_display_policy_mutex_);
+    dim_brightness_percent = battery_display_policy_.dim_brightness_percent;
+  }
+  int target_brightness = user_brightness;
+  if (power_mode == ScreenPowerMode::kDimmed) {
+    if (dim_brightness_percent > 0) {
+      target_brightness = std::clamp(dim_brightness_percent, 1, 100);
     } else {
-      target_brightness = std::max(8, std::min(18, std::max(1, user_brightness_percent_ / 3)));
+      target_brightness = std::max(8, std::min(18, std::max(1, user_brightness / 3)));
     }
-  } else if (screen_power_mode_ == ScreenPowerMode::kOff) {
+  } else if (power_mode == ScreenPowerMode::kOff) {
     target_brightness = 0;
   }
 
-  if (applied_brightness_percent_ == target_brightness) {
+  if (applied_brightness_percent_.exchange(target_brightness, std::memory_order_acq_rel) ==
+      target_brightness) {
     return;
   }
-
-  applied_brightness_percent_ = target_brightness;
   bsp_display_brightness_set(target_brightness);
 }
 
@@ -3895,38 +3898,51 @@ void Ui::update_power_save(bool on_battery, bool keep_awake, bool print_active) 
   const uint32_t now = lv_tick_get();
   const uint32_t idle_ms = now - last_activity_tick_ms_.load();
 
+  if (wake_display_requested_.exchange(false, std::memory_order_acq_rel)) {
+    wake_display();
+    return;
+  }
+
+  BatteryDisplayPolicy policy;
+  {
+    std::lock_guard<std::mutex> lock(battery_display_policy_mutex_);
+    policy = battery_display_policy_;
+  }
+
   // While the LVGL worker is paused (screen off), LVGL touch events are not
   // processed.  Poll the raw touch-interrupt GPIO so a finger press can still
   // wake the display.  CST9217 pulls INT (GPIO 11) low on contact.
-  if (screen_power_mode_ == ScreenPowerMode::kOff &&
+  if (screen_power_mode_.load(std::memory_order_acquire) == ScreenPowerMode::kOff &&
       gpio_get_level(BSP_LCD_TOUCH_INT) == 0) {
-    note_activity(true);  // updates last_activity_tick_ms_ + calls wake_display()
-    return;               // re-evaluate on next call with fresh idle_ms
+    note_activity(false);
+    wake_display();
+    return;
   }
 
   // print_active only selects the "during print" timeouts — it must NOT
   // suppress dimming/screen-off (v1.6 regression: print_active was folded
   // into keep_awake, which made the *_active_s policy timeouts dead code).
   const uint32_t dim_timeout = (print_active
-      ? battery_display_policy_.dim_timeout_active_s
-      : battery_display_policy_.dim_timeout_idle_s) * 1000U;
+      ? policy.dim_timeout_active_s
+      : policy.dim_timeout_idle_s) * 1000U;
   const uint32_t off_timeout = (print_active
-      ? battery_display_policy_.off_timeout_active_s
-      : battery_display_policy_.off_timeout_idle_s) * 1000U;
+      ? policy.off_timeout_active_s
+      : policy.off_timeout_idle_s) * 1000U;
 
   ScreenPowerMode target_mode = ScreenPowerMode::kAwake;
-  if (!keep_awake && (on_battery || battery_display_policy_.usb_power_save_enabled)) {
-    if (battery_display_policy_.screen_off_enabled && idle_ms >= off_timeout) {
+  if (!keep_awake && (on_battery || policy.usb_power_save_enabled)) {
+    if (policy.screen_off_enabled && idle_ms >= off_timeout) {
       target_mode = ScreenPowerMode::kOff;
-    } else if (battery_display_policy_.dim_enabled && idle_ms >= dim_timeout) {
+    } else if (policy.dim_enabled && idle_ms >= dim_timeout) {
       target_mode = ScreenPowerMode::kDimmed;
     }
   }
 
-  if (screen_power_mode_ != target_mode) {
-    const bool was_off = screen_power_mode_ == ScreenPowerMode::kOff;
+  const ScreenPowerMode current_mode = screen_power_mode_.load(std::memory_order_acquire);
+  if (current_mode != target_mode) {
+    const bool was_off = current_mode == ScreenPowerMode::kOff;
     const bool going_off = target_mode == ScreenPowerMode::kOff;
-    screen_power_mode_ = target_mode;
+    screen_power_mode_.store(target_mode, std::memory_order_release);
 
     // IMPORTANT: When turning the screen off, pause the LVGL worker BEFORE
     // setting brightness to 0.  The AMOLED panel stops generating the TE
@@ -3946,7 +3962,8 @@ void Ui::update_power_save(bool on_battery, bool keep_awake, bool print_active) 
         // Treat a failed screen-off attempt like fresh activity so we don't
         // immediately hammer pause() again on the next main-loop iteration.
         last_activity_tick_ms_.store(now);
-        screen_power_mode_ = was_off ? ScreenPowerMode::kOff : ScreenPowerMode::kAwake;
+        screen_power_mode_.store(was_off ? ScreenPowerMode::kOff : ScreenPowerMode::kAwake,
+                                 std::memory_order_release);
         return;
       }
     }
@@ -3960,7 +3977,7 @@ void Ui::update_power_save(bool on_battery, bool keep_awake, bool print_active) 
 }
 
 bool Ui::is_low_power_mode_active() const {
-  return screen_power_mode_ != ScreenPowerMode::kAwake;
+  return screen_power_mode_.load(std::memory_order_relaxed) != ScreenPowerMode::kAwake;
 }
 
 void Ui::pager_event_cb(lv_event_t* event) {


### PR DESCRIPTION
- Fixed hotend temperature updates for newer printer payloads, including missing or changing nozzle IDs.
- Improved local camera and cloud preview reliability by retrying transient TLS operations and handling partial network writes.
- Secured the Web Config portal with context-specific HTML, JavaScript, and JSON escaping.
- Hardened WAV upload parsing against truncated or malformed chunks.
- Made printer-profile updates transactional, reducing NVS operations and preventing partial configuration state.
- Added failure handling for OTA download and reboot task creation.
- Removed UI concurrency issues around display power state, wake requests, brightness, and printer switching.
- Reduced repeated NVS reads and unnecessary printer-card refreshes.
- Added wrap-safe cloud retry timing and reduced portal-page heap reallocations.